### PR TITLE
fix: allow sympy.Number to be used as bounds

### DIFF
--- a/optlang/cplex_interface.py
+++ b/optlang/cplex_interface.py
@@ -694,12 +694,12 @@ class Model(interface.Model):
 
     def _set_variable_bounds_on_problem(self, var_lb, var_ub):
         lb = [
-            (var.name, -cplex.infinity) if val is None else (var.name, val) for var, val in var_lb
+            (var.name, -cplex.infinity) if val is None else (var.name, float(val)) for var, val in var_lb
         ]
         if len(lb) > 0:
             self.problem.variables.set_lower_bounds(lb)
         ub = [
-            (var.name, cplex.infinity) if val is None else (var.name, val) for var, val in var_ub
+            (var.name, cplex.infinity) if val is None else (var.name, float(val)) for var, val in var_ub
         ]
         if len(ub) > 0:
             self.problem.variables.set_upper_bounds(ub)

--- a/optlang/interface.py
+++ b/optlang/interface.py
@@ -38,7 +38,7 @@ import sympy
 from sympy.core.assumptions import _assume_rules
 from sympy.core.facts import FactKB
 from sympy.core.expr import Expr
-from optlang.util import parse_expr, expr_to_json
+from optlang.util import parse_expr, expr_to_json, is_numeric
 
 from .container import Container
 
@@ -111,7 +111,7 @@ class Variable(sympy.Symbol):
 
     @staticmethod
     def __test_valid_lower_bound(type, value, name):
-        if not (value is None or isinstance(value, (float, int))):
+        if not (value is None or is_numeric(value)):
             raise TypeError("Variable bounds must be numeric or None.")
         if value is not None:
             if type == 'integer' and value % 1 != 0.:
@@ -124,7 +124,7 @@ class Variable(sympy.Symbol):
 
     @staticmethod
     def __test_valid_upper_bound(type, value, name):
-        if not (value is None or isinstance(value, (float, int))):
+        if not (value is None or is_numeric(value)):
             raise TypeError("Variable bounds must be numeric or None.")
         if value is not None:
             if type == 'integer' and value % 1 != 0.:
@@ -583,13 +583,13 @@ class Constraint(OptimizationExpression):
     _INDICATOR_CONSTRAINT_SUPPORT = True
 
     def _check_valid_lower_bound(self, value):
-        if not (value is None or isinstance(value, (int, float))):
+        if not (value is None or is_numeric(value)):
             raise TypeError("Constraint bounds must be numeric or None, not {}".format(type(value)))
         if value is not None and getattr(self, "ub", None) is not None and value > self.ub:
             raise ValueError("Cannot set a lower bound that is greater than the upper bound.")
 
     def _check_valid_upper_bound(self, value):
-        if not (value is None or isinstance(value, (int, float))):
+        if not (value is None or is_numeric(value)):
             raise TypeError("Constraint bounds must be numeric or None, not {}".format(type(value)))
         if value is not None and getattr(self, "lb", None) is not None and value < self.lb:
             raise ValueError("Cannot set an upper bound that is less than the lower bound.")

--- a/optlang/tests/abstract_test_cases.py
+++ b/optlang/tests/abstract_test_cases.py
@@ -80,8 +80,10 @@ class AbstractVariableTestCase(unittest.TestCase):
 
     def test_setting_nonnumerical_bounds_raises(self):
         self.assertRaises(TypeError, setattr, self.var, "lb", "Ministrone")
+        elf.assertRaises(TypeError, setattr, self.var, "ub", "Ministrone")
         self.model.add(self.var)
         self.assertRaises(TypeError, setattr, self.model.variables[0], 'lb', 'Chicken soup')
+        self.assertRaises(TypeError, setattr, self.model.variables[0], 'ub', 'Chicken soup')
 
     @abc.abstractmethod
     def test_changing_variable_names_is_reflected_in_the_solver(self):
@@ -212,6 +214,8 @@ class AbstractConstraintTestCase(unittest.TestCase):
         constraint = self.interface.Constraint(var, lb=0)
         self.assertRaises(TypeError, setattr, constraint, "lb", "noodle soup")
         self.assertRaises(TypeError, setattr, self.model.constraints[0], 'lb', 'Chicken soup')
+        self.assertRaises(TypeError, setattr, constraint, "ub", "noodle soup")
+        self.assertRaises(TypeError, setattr, self.model.constraints[0], 'ub', 'Chicken soup')
 
     def test_set_constraint_bounds_to_none(self):
         model = self.interface.Model()

--- a/optlang/tests/abstract_test_cases.py
+++ b/optlang/tests/abstract_test_cases.py
@@ -80,7 +80,7 @@ class AbstractVariableTestCase(unittest.TestCase):
 
     def test_setting_nonnumerical_bounds_raises(self):
         self.assertRaises(TypeError, setattr, self.var, "lb", "Ministrone")
-        elf.assertRaises(TypeError, setattr, self.var, "ub", "Ministrone")
+        self.assertRaises(TypeError, setattr, self.var, "ub", "Ministrone")
         self.model.add(self.var)
         self.assertRaises(TypeError, setattr, self.model.variables[0], 'lb', 'Chicken soup')
         self.assertRaises(TypeError, setattr, self.model.variables[0], 'ub', 'Chicken soup')

--- a/optlang/util.py
+++ b/optlang/util.py
@@ -170,6 +170,13 @@ def method_inheritdocstring(mthd):
         pass
 
 
+def is_numeric(obj):
+    if isinstance(obj, (int, float)) or getattr(obj, "is_Number", False):
+        return True
+    else:
+        return False
+
+
 def expr_to_json(expr):
     """
     Converts a Sympy expression to a json-compatible tree-structure.


### PR DESCRIPTION
Both variable and constraint bounds can now be set to sympy.Number types