### PR TITLE
bugfix: NamedTemporaryFile can't be opened twice (#34)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,40 @@
+environment:
+  global:
+    # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
+    # /E:ON and /V:ON options are not enabled in the batch script intepreter
+    # See: http://stackoverflow.com/a/13751649/163740
+    WITH_COMPILER: "cmd /E:ON /V:ON /C .\\appveyor\\run_with_env.cmd"
+    PIP_CACHE_DIR: "pip_cache"
+
+  matrix:
+    - PYTHON: "C:\\Python27-x64"
+      PYTHON_VERSION: "2.7.12"
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Python34-x64"
+      PYTHON_VERSION: "3.4.5"
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Python35-x64"
+      PYTHON_VERSION: "3.5.2"
+      PYTHON_ARCH: "64"
+
+clone_depth: 25
+
+init:
+  - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%bit"
+
+cache:
+    - pip_cache -> appveyor.yml
+
+
+install:
+  - "powershell appveyor\\install.ps1"
+  - "%PYTHON%/python -m pip install pip setuptools wheel --upgrade"
+  - "%PYTHON%/python -m pip install nose rednose swiglpk coverage jsonschema numpy"
+
+
+build: off
+
+test_script:
+  - "%WITH_COMPILER% %PYTHON%/python setup.py test"

--- a/appveyor/install.ps1
+++ b/appveyor/install.ps1
@@ -1,0 +1,85 @@
+# Sample script to install Python and pip under Windows
+# Authors: Olivier Grisel and Kyle Kastner
+# License: CC0 1.0 Universal: http://creativecommons.org/publicdomain/zero/1.0/
+
+$BASE_URL = "https://www.python.org/ftp/python/"
+$GET_PIP_URL = "https://bootstrap.pypa.io/get-pip.py"
+$GET_PIP_PATH = "C:\get-pip.py"
+
+
+function DownloadPython ($python_version, $platform_suffix) {
+    $webclient = New-Object System.Net.WebClient
+    $filename = "python-" + $python_version + $platform_suffix + ".msi"
+    $url = $BASE_URL + $python_version + "/" + $filename
+
+    $basedir = $pwd.Path + "\"
+    $filepath = $basedir + $filename
+    if (Test-Path $filename) {
+        Write-Host "Reusing" $filepath
+        return $filepath
+    }
+
+    # Download and retry up to 5 times in case of network transient errors.
+    Write-Host "Downloading" $filename "from" $url
+    $retry_attempts = 3
+    for($i=0; $i -lt $retry_attempts; $i++){
+        try {
+            $webclient.DownloadFile($url, $filepath)
+            break
+        }
+        Catch [Exception]{
+            Start-Sleep 1
+        }
+   }
+   Write-Host "File saved at" $filepath
+   return $filepath
+}
+
+
+function InstallPython ($python_version, $architecture, $python_home) {
+    Write-Host "Installing Python" $python_version "for" $architecture "bit architecture to" $python_home
+    if (Test-Path $python_home) {
+        Write-Host $python_home "already exists, skipping."
+        return $false
+    }
+    if ($architecture -eq "32") {
+        $platform_suffix = ""
+    } else {
+        $platform_suffix = ".amd64"
+    }
+    $filepath = DownloadPython $python_version $platform_suffix
+    Write-Host "Installing" $filepath "to" $python_home
+    $args = "/qn /i $filepath TARGETDIR=$python_home"
+    Write-Host "msiexec.exe" $args
+    Start-Process -FilePath "msiexec.exe" -ArgumentList $args -Wait -Passthru
+    Write-Host "Python $python_version ($architecture) installation complete"
+    return $true
+}
+
+
+function InstallPip ($python_home) {
+    $pip_path = $python_home + "/Scripts/pip.exe"
+    $python_path = $python_home + "/python.exe"
+    if (-not(Test-Path $pip_path)) {
+        Write-Host "Installing pip..."
+        $webclient = New-Object System.Net.WebClient
+        $webclient.DownloadFile($GET_PIP_URL, $GET_PIP_PATH)
+        Write-Host "Executing:" $python_path $GET_PIP_PATH
+        Start-Process -FilePath "$python_path" -ArgumentList "$GET_PIP_PATH" -Wait -Passthru
+    } else {
+        Write-Host "pip already installed."
+    }
+}
+
+function InstallPackage ($python_home, $pkg) {
+    $pip_path = $python_home + "/Scripts/pip.exe"
+    & $pip_path install $pkg
+}
+
+function main () {
+    InstallPython $env:PYTHON_VERSION $env:PYTHON_ARCH $env:PYTHON
+    InstallPip $env:PYTHON
+    InstallPackage $env:PYTHON wheel
+}
+
+main

--- a/appveyor/run_with_env.cmd
+++ b/appveyor/run_with_env.cmd
@@ -1,0 +1,88 @@
+:: To build extensions for 64 bit Python 3, we need to configure environment
+:: variables to use the MSVC 2010 C++ compilers from GRMSDKX_EN_DVD.iso of:
+:: MS Windows SDK for Windows 7 and .NET Framework 4 (SDK v7.1)
+::
+:: To build extensions for 64 bit Python 2, we need to configure environment
+:: variables to use the MSVC 2008 C++ compilers from GRMSDKX_EN_DVD.iso of:
+:: MS Windows SDK for Windows 7 and .NET Framework 3.5 (SDK v7.0)
+::
+:: 32 bit builds, and 64-bit builds for 3.5 and beyond, do not require specific
+:: environment configurations.
+::
+:: Note: this script needs to be run with the /E:ON and /V:ON flags for the
+:: cmd interpreter, at least for (SDK v7.0)
+::
+:: More details at:
+:: https://github.com/cython/cython/wiki/64BitCythonExtensionsOnWindows
+:: http://stackoverflow.com/a/13751649/163740
+::
+:: Author: Olivier Grisel
+:: License: CC0 1.0 Universal: http://creativecommons.org/publicdomain/zero/1.0/
+::
+:: Notes about batch files for Python people:
+::
+:: Quotes in values are literally part of the values:
+::      SET FOO="bar"
+:: FOO is now five characters long: " b a r "
+:: If you don't want quotes, don't include them on the right-hand side.
+::
+:: The CALL lines at the end of this file look redundant, but if you move them
+:: outside of the IF clauses, they do not run properly in the SET_SDK_64==Y
+:: case, I don't know why.
+@ECHO OFF
+
+SET COMMAND_TO_RUN=%*
+SET WIN_SDK_ROOT=C:\Program Files\Microsoft SDKs\Windows
+SET WIN_WDK=c:\Program Files (x86)\Windows Kits\10\Include\wdf
+
+:: Extract the major and minor versions, and allow for the minor version to be
+:: more than 9.  This requires the version number to have two dots in it.
+SET MAJOR_PYTHON_VERSION=%PYTHON_VERSION:~0,1%
+IF "%PYTHON_VERSION:~3,1%" == "." (
+    SET MINOR_PYTHON_VERSION=%PYTHON_VERSION:~2,1%
+) ELSE (
+    SET MINOR_PYTHON_VERSION=%PYTHON_VERSION:~2,2%
+)
+
+:: Based on the Python version, determine what SDK version to use, and whether
+:: to set the SDK for 64-bit.
+IF %MAJOR_PYTHON_VERSION% == 2 (
+    SET WINDOWS_SDK_VERSION="v7.0"
+    SET SET_SDK_64=Y
+) ELSE (
+    IF %MAJOR_PYTHON_VERSION% == 3 (
+        SET WINDOWS_SDK_VERSION="v7.1"
+        IF %MINOR_PYTHON_VERSION% LEQ 4 (
+            SET SET_SDK_64=Y
+        ) ELSE (
+            SET SET_SDK_64=N
+            IF EXIST "%WIN_WDK%" (
+                :: See: https://connect.microsoft.com/VisualStudio/feedback/details/1610302/
+                REN "%WIN_WDK%" 0wdf
+            )
+        )
+    ) ELSE (
+        ECHO Unsupported Python version: "%MAJOR_PYTHON_VERSION%"
+        EXIT 1
+    )
+)
+
+IF %PYTHON_ARCH% == 64 (
+    IF %SET_SDK_64% == Y (
+        ECHO Configuring Windows SDK %WINDOWS_SDK_VERSION% for Python %MAJOR_PYTHON_VERSION% on a 64 bit architecture
+        SET DISTUTILS_USE_SDK=1
+        SET MSSdk=1
+        "%WIN_SDK_ROOT%\%WINDOWS_SDK_VERSION%\Setup\WindowsSdkVer.exe" -q -version:%WINDOWS_SDK_VERSION%
+        "%WIN_SDK_ROOT%\%WINDOWS_SDK_VERSION%\Bin\SetEnv.cmd" /x64 /release
+        ECHO Executing: %COMMAND_TO_RUN%
+        call %COMMAND_TO_RUN% || EXIT 1
+    ) ELSE (
+        ECHO Using default MSVC build environment for 64 bit architecture
+        ECHO Executing: %COMMAND_TO_RUN%
+        call %COMMAND_TO_RUN% || EXIT 1
+    )
+) ELSE (
+    ECHO Using default MSVC build environment for 32 bit architecture
+    ECHO Executing: %COMMAND_TO_RUN%
+    call %COMMAND_TO_RUN% || EXIT 1
+)

--- a/optlang/cplex_interface.py
+++ b/optlang/cplex_interface.py
@@ -597,7 +597,7 @@ class Model(interface.Model):
         tmp_file.close()
         try:
             self.problem.write(tmp_file_name)
-            with open(tmp_file_name):
+            with open(tmp_file_name, "rb") as tmp_file:
                 cplex_binary = tmp_file.read()
         finally:
             os.remove(tmp_file_name)
@@ -609,7 +609,7 @@ class Model(interface.Model):
         tmp_file_name = tmp_file.name
         tmp_file.close()
         try:
-            with open(tmp_file_name, "w") as tmp_file:
+            with open(tmp_file_name, "wb") as tmp_file:
                 tmp_file.write(repr_dict['cplex_binary'])
             problem = cplex.Cplex()
             # turn off logging completely, get's configured later

--- a/optlang/glpk_interface.py
+++ b/optlang/glpk_interface.py
@@ -29,6 +29,7 @@ import collections
 import logging
 import tempfile
 
+import os
 import six
 import sympy
 from sympy.core.add import _unevaluated_Add
@@ -511,12 +512,16 @@ class Model(interface.Model):
         return repr_dict
 
     def __setstate__(self, repr_dict):
-        with tempfile.NamedTemporaryFile(suffix=".glpk", delete=True) as tmp_file:
-            tmp_file_name = tmp_file.name
-            with open(tmp_file_name, 'w') as tmp_file:
+        tmp_file = tempfile.NamedTemporaryFile(suffix=".glpk", delete=False, mode='wb')
+        tmp_file_name = tmp_file.name
+        tmp_file.close()
+        try:
+            with open(tmp_file_name, "w") as tmp_file:
                 tmp_file.write(repr_dict['glpk_repr'])
-                problem = glp_create_prob()
+            problem = glp_create_prob()
             glp_read_prob(problem, 0, tmp_file_name)
+        finally:
+            os.remove(tmp_file_name)
         self.__init__(problem=problem)
         self.configuration = Configuration.clone(repr_dict['config'], problem=self)
         if repr_dict['glpk_status'] == 'optimal':
@@ -591,19 +596,27 @@ class Model(interface.Model):
         return shadow_prices
 
     def __str__(self):
-        with tempfile.NamedTemporaryFile(suffix=".lp", delete=True) as tmp_file:
-            tmp_file_name = tmp_file.name
-            glp_write_lp(self.problem, None, tmp_file_name)
+        tmp_file = tempfile.NamedTemporaryFile(suffix=".lp", mode='r', delete=True)
+        tmp_file_name = tmp_file.name
+        tmp_file.close()
+        try:
+            glp_write_lp(self.problem, None, tmp_file.name)
             with open(tmp_file_name) as tmp_file:
                 cplex_form = tmp_file.read()
+        finally:
+            os.remove(tmp_file_name)
         return cplex_form
 
     def _glpk_representation(self):
-        with tempfile.NamedTemporaryFile(suffix=".glpk", delete=True) as tmp_file:
-            tmp_file_name = tmp_file.name
-            glp_write_prob(self.problem, 0, tmp_file_name)
+        tmp_file = tempfile.NamedTemporaryFile(suffix=".glpk", delete=True)
+        tmp_file_name = tmp_file.name
+        tmp_file.close()
+        try:
+            glp_write_prob(self.problem, 0, tmp_file.name)
             with open(tmp_file_name) as tmp_file:
                 glpk_form = tmp_file.read()
+        finally:
+            os.remove(tmp_file_name)
         return glpk_form
 
     def _run_glp_simplex(self):

--- a/optlang/glpk_interface.py
+++ b/optlang/glpk_interface.py
@@ -596,7 +596,7 @@ class Model(interface.Model):
         return shadow_prices
 
     def __str__(self):
-        tmp_file = tempfile.NamedTemporaryFile(suffix=".lp", mode='r', delete=True)
+        tmp_file = tempfile.NamedTemporaryFile(suffix=".lp", mode='r', delete=False)
         tmp_file_name = tmp_file.name
         tmp_file.close()
         try:
@@ -608,7 +608,7 @@ class Model(interface.Model):
         return cplex_form
 
     def _glpk_representation(self):
-        tmp_file = tempfile.NamedTemporaryFile(suffix=".glpk", delete=True)
+        tmp_file = tempfile.NamedTemporaryFile(suffix=".glpk", delete=False)
         tmp_file_name = tmp_file.name
         tmp_file.close()
         try:

--- a/optlang/tests/test_scipy_interface.py
+++ b/optlang/tests/test_scipy_interface.py
@@ -1,9 +1,22 @@
 # Copyright (c) 2013 Novo Nordisk Foundation Center for Biosustainability, DTU.
 # See LICENSE for details.
 
-from optlang import scipy_interface
 import unittest
 
 
-class ScipyInterfaceTestCase(unittest.TestCase):
-    pass
+try:
+    import scipy
+except ImportError as e:
+    if str(e).find('scipy') >= 0:
+        class TestMissingDependency(unittest.TestCase):
+
+            @unittest.skip('Missing dependency - ' + str(e))
+            def test_fail(self):
+                pass
+    else:
+        raise
+else:
+    from optlang import scipy_interface
+
+    class ScipyInterfaceTestCase(unittest.TestCase):
+        pass

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,16 @@
 # content of: tox.ini , put in same dir as setup.py
 [tox]
-envlist = py27,py33,py34,py35
+envlist = py27,py35
+
+[testenv:flake8]
+deps=flake8
+commands=flake8 .
+
 [testenv]
 deps=nose
      rednose
      swiglpk
      coverage
+     jsonschema
+     numpy
 commands=nosetests


### PR DESCRIPTION
* bugfix: NamedTemporaryFile can't be opened twice

..on Windows we get

self = <optlang.glpk_interface.Model object at 0x09695550>
    def _glpk_representation(self):
        with tempfile.NamedTemporaryFile(suffix=".glpk", delete=True) as tmp_file:
            tmp_file_name = tmp_file.name
            glp_write_prob(self.problem, 0, tmp_file_name)
>           with open(tmp_file_name) as tmp_file:
E           IOError: [Errno 13] Permission denied: 'c:\\users\\appveyor\\appdata\\local\\temp\\1\\tmptwsotv.glpk'

solution found in

http://stackoverflow.com/questions/23212435/permission-denied-to-write-to-my-temporary-file

* fix: bug in gurobi interface

* fix: missing flush commands for py27

* fix also read-mode files can't be opened twice

* feat: use appveyor for basic testing on windows

doesn't use scipy as seems complicated to install

* fix: allow sympy.Number to be used as bounds (#35)

* fix: allow sympy.Number to be used as bounds

Both variable and constraint bounds can now be set to sympy.Number types

* test: add a bit more testing

* fix: typo

* Update cplex_interface.py

* Update glpk_interface.py

* Update gurobi_interface.py

* fix: explicitly close and delete tempfiles

* fix: explicitly close and delete tempfiles, cplex

* fix: explicitly close and delete tempfile, gurobi

* fix: typo - use delete=False