### PR TITLE
Clone with lp format

### DIFF
--- a/optlang/cplex_interface.py
+++ b/optlang/cplex_interface.py
@@ -589,6 +589,14 @@ class Model(interface.Model):
             raise TypeError("Provided problem is not a valid CPLEX model.")
         self.configuration = Configuration(problem=self, verbosity=0)
 
+    @classmethod
+    def from_lp(cls, lp_form):
+        problem = cplex.Cplex()
+        with TemporaryFilename(suffix=".lp", content=lp_form) as tmp_file_name:
+            problem.read(tmp_file_name)
+        model = cls(problem=problem)
+        return model
+
     def __getstate__(self):
         self.update()
         with TemporaryFilename(suffix=".sav") as tmp_file_name:
@@ -675,7 +683,7 @@ class Model(interface.Model):
         return collections.OrderedDict(
             zip((constraint.name for constraint in self.constraints), self.problem.solution.get_dual_values()))
 
-    def __str__(self):
+    def to_lp(self):
         with TemporaryFilename(suffix=".lp") as tmp_file_name:
             self.problem.write(tmp_file_name)
             with open(tmp_file_name) as tmp_file:

--- a/optlang/cplex_interface.py
+++ b/optlang/cplex_interface.py
@@ -684,6 +684,7 @@ class Model(interface.Model):
             zip((constraint.name for constraint in self.constraints), self.problem.solution.get_dual_values()))
 
     def to_lp(self):
+        self.update()
         with TemporaryFilename(suffix=".lp") as tmp_file_name:
             self.problem.write(tmp_file_name)
             with open(tmp_file_name) as tmp_file:

--- a/optlang/cplex_interface.py
+++ b/optlang/cplex_interface.py
@@ -31,14 +31,13 @@ from six.moves import StringIO
 
 log = logging.getLogger(__name__)
 
-import tempfile
 import sympy
 from sympy.core.add import _unevaluated_Add
 from sympy.core.mul import _unevaluated_Mul
 from sympy.core.singleton import S
 import cplex
 from optlang import interface
-from optlang.util import inheritdocstring
+from optlang.util import inheritdocstring, TemporaryFilename
 from optlang.expression_parsing import parse_optimization_expression
 
 Zero = S.Zero
@@ -592,25 +591,17 @@ class Model(interface.Model):
 
     def __getstate__(self):
         self.update()
-        tmp_file = tempfile.NamedTemporaryFile(suffix=".sav", delete=False)
-        tmp_file_name = tmp_file.name
-        tmp_file.close()
-        try:
+        with TemporaryFilename(suffix=".sav") as tmp_file_name:
             self.problem.write(tmp_file_name)
             with open(tmp_file_name, "rb") as tmp_file:
                 cplex_binary = tmp_file.read()
-        finally:
-            os.remove(tmp_file_name)
         repr_dict = {'cplex_binary': cplex_binary, 'status': self.status, 'config': self.configuration}
         return repr_dict
 
     def __setstate__(self, repr_dict):
-        tmp_file = tempfile.NamedTemporaryFile(suffix=".sav", delete=False, mode='wb')
-        tmp_file_name = tmp_file.name
-        tmp_file.close()
-        try:
+        with TemporaryFilename(suffix=".sav") as tmp_file_name:
             with open(tmp_file_name, "wb") as tmp_file:
-                tmp_file.write(repr_dict['cplex_binary'])
+                tmp_file.write(repr_dict["cplex_binary"])
             problem = cplex.Cplex()
             # turn off logging completely, get's configured later
             problem.set_error_stream(None)
@@ -618,8 +609,6 @@ class Model(interface.Model):
             problem.set_log_stream(None)
             problem.set_results_stream(None)
             problem.read(tmp_file_name)
-        finally:
-            os.remove(tmp_file_name)
         if repr_dict['status'] == 'optimal':
             problem.solve()  # since the start is an optimal solution, nothing will happen here
         self.__init__(problem=problem)
@@ -687,16 +676,11 @@ class Model(interface.Model):
             zip((constraint.name for constraint in self.constraints), self.problem.solution.get_dual_values()))
 
     def __str__(self):
-        tmp_file = tempfile.NamedTemporaryFile(suffix=".lp", mode='r', delete=False)
-        tmp_file_name = tmp_file.name
-        tmp_file.close()
-        try:
-            self.problem.write(tmp_file.name)
+        with TemporaryFilename(suffix=".lp") as tmp_file_name:
+            self.problem.write(tmp_file_name)
             with open(tmp_file_name) as tmp_file:
-                cplex_form = tmp_file.read()
-        finally:
-            os.remove(tmp_file_name)
-        return cplex_form
+                lp_form = tmp_file.read()
+        return lp_form
 
     def _optimize(self):
         self.problem.solve()

--- a/optlang/glpk_interface.py
+++ b/optlang/glpk_interface.py
@@ -513,7 +513,6 @@ class Model(interface.Model):
         return model
 
     def __getstate__(self):
-        self.update()
         glpk_repr = self._glpk_representation()
         repr_dict = {'glpk_repr': glpk_repr, 'glpk_status': self.status, 'config': self.configuration}
         return repr_dict
@@ -596,6 +595,7 @@ class Model(interface.Model):
         return shadow_prices
 
     def to_lp(self):
+        self.update()
         with TemporaryFilename(suffix=".lp") as tmp_file_name:
             glp_write_lp(self.problem, None, tmp_file_name)
             with open(tmp_file_name) as tmp_file:
@@ -603,6 +603,7 @@ class Model(interface.Model):
         return lp_form
 
     def _glpk_representation(self):
+        self.update()
         with TemporaryFilename(suffix=".glpk") as tmp_file_name:
             glp_write_prob(self.problem, 0, tmp_file_name)
             with open(tmp_file_name) as tmp_file:

--- a/optlang/glpk_interface.py
+++ b/optlang/glpk_interface.py
@@ -51,7 +51,7 @@ from swiglpk import glp_find_col, glp_get_col_prim, glp_get_col_dual, GLP_CV, GL
     glp_set_mat_row, glp_set_col_bnds, glp_set_row_bnds, GLP_FR, GLP_UP, GLP_LO, GLP_FX, GLP_DB, glp_del_rows, \
     glp_get_mat_row, glp_get_row_ub, glp_get_row_type, glp_get_row_lb, glp_get_row_name, glp_get_obj_coef, \
     glp_get_obj_dir, glp_scale_prob, GLP_SF_AUTO, glp_get_num_int, glp_get_num_bin, glp_mip_col_val, \
-    glp_mip_obj_val, glp_mip_status, GLP_ETMLIM, glp_adv_basis
+    glp_mip_obj_val, glp_mip_status, GLP_ETMLIM, glp_adv_basis, glp_read_lp
 
 
 
@@ -504,6 +504,14 @@ class Model(interface.Model):
                 direction={GLP_MIN: 'min', GLP_MAX: 'max'}[glp_get_obj_dir(self.problem)])
         glp_scale_prob(self.problem, GLP_SF_AUTO)
 
+    @classmethod
+    def from_lp(cls, lp_form):
+        problem = glp_create_prob()
+        with TemporaryFilename(suffix=".lp", content=lp_form) as tmp_file_name:
+            glp_read_lp(problem, None, tmp_file_name)
+        model = cls(problem=problem)
+        return model
+
     def __getstate__(self):
         self.update()
         glpk_repr = self._glpk_representation()
@@ -587,7 +595,7 @@ class Model(interface.Model):
             shadow_prices[constraint.name] = value
         return shadow_prices
 
-    def __str__(self):
+    def to_lp(self):
         with TemporaryFilename(suffix=".lp") as tmp_file_name:
             glp_write_lp(self.problem, None, tmp_file_name)
             with open(tmp_file_name) as tmp_file:

--- a/optlang/glpk_interface.py
+++ b/optlang/glpk_interface.py
@@ -800,8 +800,6 @@ if __name__ == '__main__':
 
     print(model)
 
-    from swiglpk import glp_read_lp
-
     problem = glp_create_prob()
     glp_read_lp(problem, None, "../tests/data/model.lp")
 

--- a/optlang/gurobi_interface.py
+++ b/optlang/gurobi_interface.py
@@ -454,6 +454,13 @@ class Model(interface.Model):
 
         self.configuration = Configuration(problem=self, verbosity=0)
 
+    @classmethod
+    def from_lp(cls, lp_form):
+        with TemporaryFilename(suffix=".lp", content=lp_form) as tmp_file_name:
+            problem = gurobipy.read(tmp_file_name)
+        model = cls(problem=problem)
+        return model
+
     def __getstate__(self):
         self.update()
         with TemporaryFilename(suffix=".lp") as tmp_file_name:
@@ -476,7 +483,7 @@ class Model(interface.Model):
         self.__init__(problem=problem)
         self.configuration = Configuration.clone(repr_dict['config'], problem=self)  # TODO: make configuration work
 
-    def __str__(self):
+    def to_lp(self):
         self.problem.update()
         with TemporaryFilename(suffix=".lp") as tmp_file_name:
             self.problem.write(tmp_file_name)

--- a/optlang/gurobi_interface.py
+++ b/optlang/gurobi_interface.py
@@ -472,7 +472,7 @@ class Model(interface.Model):
 
     def __setstate__(self, repr_dict):
         with TemporaryFilename(suffix=".lp", content=repr_dict["lp"]) as tmp_file_name:
-            problem = gurobipy.read(tmp_file.name)
+            problem = gurobipy.read(tmp_file_name)
         # if repr_dict['status'] == 'optimal':  # TODO: uncomment this
         #     # turn off logging completely, get's configured later
         #     problem.set_error_stream(None)

--- a/optlang/interface.py
+++ b/optlang/interface.py
@@ -1100,12 +1100,6 @@ class Model(object):
         if constraints is not None:
             self.add(constraints)
 
-    def __str__(self):
-        if hasattr(self, "to_lp"):
-            return self.to_lp()
-        else:
-            return repr(self)
-
     @property
     def interface(self):
         """Provides access to the solver interface the model belongs to
@@ -1199,6 +1193,8 @@ class Model(object):
         return collections.OrderedDict([(constraint.name, constraint.dual) for constraint in self.constraints])
 
     def __str__(self):
+        if hasattr(self, "to_lp"):
+            return self.to_lp()
         self.update()
         return '\n'.join((
             str(self.objective),

--- a/optlang/interface.py
+++ b/optlang/interface.py
@@ -1040,7 +1040,7 @@ class Model(object):
     """
 
     @classmethod
-    def clone(cls, model):
+    def clone(cls, model, use_lp=True):
         """
         Make a copy of a model. The model being copied can be of the same type or belong to
         a different solver interface. This is the preferred way of copying models.
@@ -1051,7 +1051,7 @@ class Model(object):
         """
         model.update()
         interface = sys.modules[cls.__module__]
-        if hasattr(cls, "from_lp") and hasattr(model, "to_lp"):
+        if use_lp and hasattr(cls, "from_lp") and hasattr(model, "to_lp"):
             new_model = cls.from_lp(model.to_lp())
             new_model.configuration = interface.Configuration.clone(model.configuration, problem=new_model)
             return new_model

--- a/optlang/interface.py
+++ b/optlang/interface.py
@@ -1051,6 +1051,11 @@ class Model(object):
         """
         model.update()
         interface = sys.modules[cls.__module__]
+        if hasattr(cls, "from_lp") and hasattr(model, "to_lp"):
+            new_model = cls.from_lp(model.to_lp())
+            new_model.configuration = interface.Configuration.clone(model.configuration, problem=new_model)
+            return new_model
+
         new_model = cls()
         for variable in model.variables:
             new_variable = interface.Variable.clone(variable)
@@ -1094,6 +1099,12 @@ class Model(object):
             self.add(variables)
         if constraints is not None:
             self.add(constraints)
+
+    def __str__(self):
+        if hasattr(self, "to_lp"):
+            return self.to_lp()
+        else:
+            return repr(self)
 
     @property
     def interface(self):

--- a/optlang/tests/abstract_test_cases.py
+++ b/optlang/tests/abstract_test_cases.py
@@ -518,10 +518,18 @@ class AbstractModelTestCase(unittest.TestCase):
         self.model.update()
         self.model.objective = self.interface.Objective(self.model.variables[1] * 2)
 
-    def test_clone_model(self):
+    def test_clone_model_with_lp(self):
         self.assertEquals(self.model.configuration.verbosity, 0)
         self.model.configuration.verbosity = 3
         cloned_model = self.interface.Model.clone(self.model)
+        self.assertEquals(cloned_model.configuration.verbosity, 3)
+        self.assertEquals(len(cloned_model.variables), len(self.model.variables))
+        self.assertEquals(len(cloned_model.constraints), len(self.model.constraints))
+
+    def test_clone_model_without_lp(self):
+        self.assertEquals(self.model.configuration.verbosity, 0)
+        self.model.configuration.verbosity = 3
+        cloned_model = self.interface.Model.clone(self.model, use_lp=False)
         self.assertEquals(cloned_model.configuration.verbosity, 3)
         self.assertEquals(len(cloned_model.variables), len(self.model.variables))
         self.assertEquals(len(cloned_model.constraints), len(self.model.constraints))

--- a/optlang/util.py
+++ b/optlang/util.py
@@ -225,6 +225,39 @@ def parse_expr(expr, local_dict=None):
         raise NotImplementedError(expr["type"] + " is not implemented")
 
 
+class TemporaryFilename(object):
+    """
+    Use context manager to create a temporary file that can be opened and closed, and will be deleted in the end.
+
+    Parameters
+    ----------
+    suffix : str
+        The file ending. Default is 'tmp'
+    content : str or None
+        If str, the content will be written to the file upon creation
+
+    Example
+    ----------
+    >>> with TemporaryFilename() as tmp_file_name:
+    >>>     with open(tmp_file_name, "w") as tmp_file:
+    >>>         tmp_file.write(stuff)
+    >>>     with open(tmp_file) as tmp_file:
+    >>>         stuff = tmp_file.read()
+    """
+    def __init__(self, suffix="tmp", content=None):
+        tmp_file = tempfile.NamedTemporaryFile(suffix=suffix, delete=False, mode="w")
+        if content is not None:
+            tmp_file.write(content)
+        self.name = tmp_file.name
+        tmp_file.close()
+
+    def __enter__(self):
+        return self.name
+
+    def __exit__(self, type, value, traceback):
+        os.remove(self.name)
+
+
 if __name__ == '__main__':
     from swiglpk import glp_create_prob, glp_read_lp, glp_get_num_rows
 


### PR DESCRIPTION
Models can now be cloned using an LP format intermediate. iJO1366 can be cloned in <500 ms.

If a solver interface doesn’t support LP formats, the old clone method will be used.