### PR TITLE
Fix recursion error

### DIFF
--- a/optlang/cplex_interface.py
+++ b/optlang/cplex_interface.py
@@ -299,10 +299,10 @@ class Constraint(interface.Constraint):
 
 @six.add_metaclass(inheritdocstring)
 class Objective(interface.Objective):
-    def __init__(self, *args, **kwargs):
-        super(Objective, self).__init__(*args, **kwargs)
+    def __init__(self, expression, sloppy=False, **kwargs):
+        super(Objective, self).__init__(expression, **kwargs)
         self._expression_expired = False
-        if not (self.is_Linear or self.is_Quadratic):
+        if not (sloppy or self.is_Linear or self.is_Quadratic):
             raise ValueError("Cplex only supports linear and quadratic objectives.")
 
     @property

--- a/optlang/glpk_interface.py
+++ b/optlang/glpk_interface.py
@@ -270,10 +270,10 @@ class Constraint(interface.Constraint):
 
 @six.add_metaclass(inheritdocstring)
 class Objective(interface.Objective):
-    def __init__(self, *args, **kwargs):
-        super(Objective, self).__init__(*args, **kwargs)
+    def __init__(self, expression, sloppy=False, **kwargs):
+        super(Objective, self).__init__(expression, **kwargs)
         self._expression_expired = False
-        if not self.is_Linear:
+        if not (sloppy or self.is_Linear):
             raise ValueError(
                 "GLPK only supports linear objectives. %s is not linear." % self)
 

--- a/optlang/gurobi_interface.py
+++ b/optlang/gurobi_interface.py
@@ -300,7 +300,7 @@ class Objective(interface.Objective):
     def __init__(self, expression, sloppy=False, *args, **kwargs):
         super(Objective, self).__init__(expression, *args, **kwargs)
         self._expression_expired = False
-        if not sloppy and not self.is_Linear:  # or self.is_Quadratic: # QP is not yet supported
+        if not (sloppy or self.is_Linear):  # or self.is_Quadratic: # QP is not yet supported
             raise ValueError("The given objective is invalid. Must be linear or quadratic (not yet supported")
 
     @property

--- a/optlang/interface.py
+++ b/optlang/interface.py
@@ -460,14 +460,15 @@ class OptimizationExpression(object):
     def is_Linear(self):
         """Returns True if expression is linear (a polynomial with degree 1 or 0) (read-only)."""
         coeff_dict = self.expression.as_coefficients_dict()
-        if all((len(key.free_symbols) < 2 and (key.is_Add or key.is_Mul or key.is_Atom) for key in coeff_dict.keys())):
-            return True
-        else:
-            poly = self.expression.as_poly(*self.variables)
-            if poly is not None:
-                return poly.is_linear
+        for key in coeff_dict.keys():
+            if len(key.free_symbols) < 2 and (key.is_Add or key.is_Mul or key.is_Atom):
+                pass
             else:
                 return False
+            if key.is_Pow and key.args[1] != 1:
+                return False
+        else:
+            return True
 
     @property
     def is_Quadratic(self):

--- a/optlang/interface.py
+++ b/optlang/interface.py
@@ -1458,6 +1458,7 @@ class Model(object):
         model.update()
         return model
 
+
 if __name__ == '__main__':
     # Example workflow
 


### PR DESCRIPTION
Fixes #41
Using sloppy=True when constructing objectives will bypass validation of the expression (i.e. is_Linear and is_Quadratic)