### PR TITLE
fix: make model.Clone use json as default

### DIFF
--- a/optlang/interface.py
+++ b/optlang/interface.py
@@ -1041,7 +1041,7 @@ class Model(object):
     """
 
     @classmethod
-    def clone(cls, model, use_lp=True):
+    def clone(cls, model, use_json=True, use_lp=False):
         """
         Make a copy of a model. The model being copied can be of the same type or belong to
         a different solver interface. This is the preferred way of copying models.
@@ -1052,8 +1052,14 @@ class Model(object):
         """
         model.update()
         interface = sys.modules[cls.__module__]
+
         if use_lp and hasattr(cls, "from_lp") and hasattr(model, "to_lp"):
             new_model = cls.from_lp(model.to_lp())
+            new_model.configuration = interface.Configuration.clone(model.configuration, problem=new_model)
+            return new_model
+
+        if use_json:
+            new_model = cls.from_json(model.to_json())
             new_model.configuration = interface.Configuration.clone(model.configuration, problem=new_model)
             return new_model
 

--- a/optlang/interface.py
+++ b/optlang/interface.py
@@ -28,6 +28,7 @@ import inspect
 import logging
 import sys
 import uuid
+import warnings
 
 import six
 

--- a/optlang/interface.py
+++ b/optlang/interface.py
@@ -1053,7 +1053,8 @@ class Model(object):
         model.update()
         interface = sys.modules[cls.__module__]
 
-        if use_lp and hasattr(cls, "from_lp") and hasattr(model, "to_lp"):
+        if use_lp:
+            warnings.warn("Cloning with LP formats can change variable and constraint ID's.")
             new_model = cls.from_lp(model.to_lp())
             new_model.configuration = interface.Configuration.clone(model.configuration, problem=new_model)
             return new_model

--- a/optlang/tests/abstract_test_cases.py
+++ b/optlang/tests/abstract_test_cases.py
@@ -521,18 +521,38 @@ class AbstractModelTestCase(unittest.TestCase):
     def test_clone_model_with_json(self):
         self.assertEquals(self.model.configuration.verbosity, 0)
         self.model.configuration.verbosity = 3
+        self.model.optimize()
+        opt = self.model.objective.value
         cloned_model = self.interface.Model.clone(self.model)
         self.assertEquals(cloned_model.configuration.verbosity, 3)
         self.assertEquals(len(cloned_model.variables), len(self.model.variables))
         self.assertEquals(len(cloned_model.constraints), len(self.model.constraints))
+        cloned_model.optimize()
+        self.assertAlmostEqual(cloned_model.objective.value, opt)
+
+    def test_clone_model_with_lp(self):
+        self.assertEquals(self.model.configuration.verbosity, 0)
+        self.model.configuration.verbosity = 3
+        self.model.optimize()
+        opt = self.model.objective.value
+        cloned_model = self.interface.Model.clone(self.model, use_lp=True)
+        self.assertEquals(cloned_model.configuration.verbosity, 3)
+        self.assertEquals(len(cloned_model.variables), len(self.model.variables))
+        self.assertEquals(len(cloned_model.constraints), len(self.model.constraints))
+        cloned_model.optimize()
+        self.assertAlmostEqual(cloned_model.objective.value, opt)
 
     def test_clone_model_without_json(self):
         self.assertEquals(self.model.configuration.verbosity, 0)
         self.model.configuration.verbosity = 3
+        self.model.optimize()
+        opt = self.model.objective.value
         cloned_model = self.interface.Model.clone(self.model, use_json=False)
         self.assertEquals(cloned_model.configuration.verbosity, 3)
         self.assertEquals(len(cloned_model.variables), len(self.model.variables))
         self.assertEquals(len(cloned_model.constraints), len(self.model.constraints))
+        cloned_model.optimize()
+        self.assertAlmostEqual(cloned_model.objective.value, opt)
 
 
 @six.add_metaclass(abc.ABCMeta)

--- a/optlang/tests/abstract_test_cases.py
+++ b/optlang/tests/abstract_test_cases.py
@@ -518,7 +518,7 @@ class AbstractModelTestCase(unittest.TestCase):
         self.model.update()
         self.model.objective = self.interface.Objective(self.model.variables[1] * 2)
 
-    def test_clone_model_with_lp(self):
+    def test_clone_model_with_json(self):
         self.assertEquals(self.model.configuration.verbosity, 0)
         self.model.configuration.verbosity = 3
         cloned_model = self.interface.Model.clone(self.model)
@@ -526,10 +526,10 @@ class AbstractModelTestCase(unittest.TestCase):
         self.assertEquals(len(cloned_model.variables), len(self.model.variables))
         self.assertEquals(len(cloned_model.constraints), len(self.model.constraints))
 
-    def test_clone_model_without_lp(self):
+    def test_clone_model_without_json(self):
         self.assertEquals(self.model.configuration.verbosity, 0)
         self.model.configuration.verbosity = 3
-        cloned_model = self.interface.Model.clone(self.model, use_lp=False)
+        cloned_model = self.interface.Model.clone(self.model, use_json=False)
         self.assertEquals(cloned_model.configuration.verbosity, 3)
         self.assertEquals(len(cloned_model.variables), len(self.model.variables))
         self.assertEquals(len(cloned_model.constraints), len(self.model.constraints))


### PR DESCRIPTION
Using LP format as intermediate has problems on cross-solver clones.