### PR TITLE
Fix bug with changing var names

### DIFF
--- a/optlang/interface.py
+++ b/optlang/interface.py
@@ -209,7 +209,7 @@ class Variable(sympy.Symbol):
     def name(self, value):
         old_name = getattr(self, 'name', None)
         self._name = value
-        if getattr(self, 'problem', None) is not None:
+        if getattr(self, 'problem', None) is not None and value != old_name:
             self.problem.variables.update_key(old_name)
             self.problem._variables_to_constraints_mapping[value] = self.problem._variables_to_constraints_mapping[old_name]
             del self.problem._variables_to_constraints_mapping[old_name]


### PR DESCRIPTION
Only update the _variables_to_constriants_mapping dict when new_name !=
old_name