### PR TITLE
Fix MIP dual value behaviour

### DIFF
--- a/optlang/cplex_interface.py
+++ b/optlang/cplex_interface.py
@@ -197,7 +197,7 @@ class Variable(interface.Variable):
     def dual(self):
         if self.problem is not None:
             if self.problem.is_integer:
-                return None
+                raise ValueError("Dual values are not well-defined for integer problems")
             return self.problem.problem.solution.get_reduced_costs(self.name)
         else:
             return None
@@ -265,7 +265,7 @@ class Constraint(interface.Constraint):
     def dual(self):
         if self.problem is not None:
             if self.problem.is_integer:
-                return None
+                raise ValueError("Dual values are not well-defined for integer problems")
             return self.problem.problem.solution.get_dual_values(self.name)
         else:
             return None
@@ -719,7 +719,7 @@ class Model(interface.Model):
     @property
     def reduced_costs(self):
         if self.is_integer:
-            return collections.OrderedDict((var.name, None) for var in self.variables)
+            raise ValueError("Dual values are not well-defined for integer problems")
         else:
             return collections.OrderedDict(
                 zip((variable.name for variable in self.variables), self.problem.solution.get_reduced_costs()))
@@ -733,7 +733,7 @@ class Model(interface.Model):
     @property
     def shadow_prices(self):
         if self.is_integer:
-            return collections.OrderedDict((var.name, None) for var in self.variables)
+            raise ValueError("Dual values are not well-defined for integer problems")
         else:
             return collections.OrderedDict(
                 zip((constraint.name for constraint in self.constraints), self.problem.solution.get_dual_values()))

--- a/optlang/cplex_interface.py
+++ b/optlang/cplex_interface.py
@@ -138,6 +138,7 @@ _CPLEX_MIP_TYPES_TO_CONTINUOUS = {
     cplex.Cplex.problem_type.MIQCP: cplex.Cplex.problem_type.QCP
 }
 
+
 def _constraint_lb_and_ub_to_cplex_sense_rhs_and_range_value(lb, ub):
     """Helper function used by Constraint and Model"""
     if lb is None and ub is None:

--- a/optlang/cplex_interface.py
+++ b/optlang/cplex_interface.py
@@ -132,6 +132,11 @@ _VTYPE_TO_CPLEX_VTYPE = dict(
     [(val, key) for key, val in six.iteritems(_CPLEX_VTYPE_TO_VTYPE)]
 )
 
+_CPLEX_MIP_TYPES_TO_CONTINUOUS = {
+    cplex.Cplex.problem_type.MILP: cplex.Cplex.problem_type.LP,
+    cplex.Cplex.problem_type.MIQP: cplex.Cplex.problem_type.QP,
+    cplex.Cplex.problem_type.MIQCP: cplex.Cplex.problem_type.QCP
+}
 
 def _constraint_lb_and_ub_to_cplex_sense_rhs_and_range_value(lb, ub):
     """Helper function used by Constraint and Model"""
@@ -175,6 +180,12 @@ class Variable(interface.Variable):
                     ", ".join(_VTYPE_TO_CPLEX_VTYPE.keys())
                 )
             self.problem.problem.variables.set_types(self.name, cplex_kind)
+            if value == "continuous" and not self.problem.is_integer:
+                print("hmm")
+                cplex_type = self.problem.problem.get_problem_type()
+                if cplex_type in _CPLEX_MIP_TYPES_TO_CONTINUOUS:
+                    print("yes")
+                    self.problem.problem.set_problem_type(_CPLEX_MIP_TYPES_TO_CONTINUOUS[cplex_type])
         super(Variable, Variable).type.fset(self, value)
 
     def _get_primal(self):
@@ -184,7 +195,7 @@ class Variable(interface.Variable):
     @property
     def dual(self):
         if self.problem is not None:
-            if self.problem.problem.get_problem_type() == self.problem.problem.problem_type.MILP:  # cplex cannot determine reduced costs for MILP problems ...
+            if self.problem.is_integer:
                 return None
             return self.problem.problem.solution.get_reduced_costs(self.name)
         else:
@@ -252,22 +263,23 @@ class Constraint(interface.Constraint):
     @property
     def dual(self):
         if self.problem is not None:
+            if self.problem.is_integer:
+                return None
             return self.problem.problem.solution.get_dual_values(self.name)
         else:
             return None
 
     @interface.Constraint.name.setter
     def name(self, value):
-        old_name = getattr(self, 'name', None)
-        self._name = value
         if getattr(self, 'problem', None) is not None:
             if self.indicator_variable is not None:
                 raise NotImplementedError(
                     "Unfortunately, the CPLEX python bindings don't support changing an indicator constraint's name"
                 )
             else:
-                self.problem.problem.linear_constraints.set_names(old_name, value)
-            self.problem.constraints.update_key(old_name)
+                self.problem.problem.linear_constraints.set_names(self.name, value)
+            self.problem.constraints.update_key(self.name)
+        self._name = value
 
     @interface.Constraint.lb.setter
     def lb(self, value):
@@ -705,8 +717,11 @@ class Model(interface.Model):
 
     @property
     def reduced_costs(self):
-        return collections.OrderedDict(
-            zip((variable.name for variable in self.variables), self.problem.solution.get_reduced_costs()))
+        if self.is_integer:
+            return collections.OrderedDict((var.name, None) for var in self.variables)
+        else:
+            return collections.OrderedDict(
+                zip((variable.name for variable in self.variables), self.problem.solution.get_reduced_costs()))
 
     @property
     def constraint_values(self):
@@ -716,8 +731,15 @@ class Model(interface.Model):
 
     @property
     def shadow_prices(self):
-        return collections.OrderedDict(
-            zip((constraint.name for constraint in self.constraints), self.problem.solution.get_dual_values()))
+        if self.is_integer:
+            return collections.OrderedDict((var.name, None) for var in self.variables)
+        else:
+            return collections.OrderedDict(
+                zip((constraint.name for constraint in self.constraints), self.problem.solution.get_dual_values()))
+
+    @property
+    def is_integer(self):
+        return (self.problem.variables.get_num_integer() + self.problem.variables.get_num_binary()) > 0
 
     def to_lp(self):
         self.update()

--- a/optlang/gurobi_interface.py
+++ b/optlang/gurobi_interface.py
@@ -642,6 +642,11 @@ class Model(interface.Model):
         for internal_constraint in internal_constraints:
             self.problem.remove(internal_constraint)
 
+    @property
+    def is_integer(self):
+        self.problem.update()
+        return self.problem.NumIntVars > 0
+
 
 if __name__ == '__main__':
     x = Variable('x', lb=0, ub=10)

--- a/optlang/gurobi_interface.py
+++ b/optlang/gurobi_interface.py
@@ -166,6 +166,8 @@ class Variable(interface.Variable):
     @property
     def dual(self):
         if self.problem:
+            if self.problem.is_integer:
+                raise ValueError("Dual values are not well-defined for integer problems")
             return self._internal_variable.getAttr('RC')
         else:
             return None
@@ -253,6 +255,8 @@ class Constraint(interface.Constraint):
     @property
     def dual(self):
         if self.problem is not None:
+            if self.problem.is_integer:
+                raise ValueError("Dual values are not well-defined for integer problems")
             return self._internal_constraint.Pi
         else:
             return None

--- a/optlang/interface.py
+++ b/optlang/interface.py
@@ -1222,6 +1222,8 @@ class Model(object):
         collections.OrderedDict
         """
         # Fallback, if nothing faster is available
+        if self.is_integer:
+            raise ValueError("Dual values are not well-defined for integer problems")
         return collections.OrderedDict([(variable.name, variable.dual) for variable in self.variables])
 
     @property
@@ -1243,6 +1245,8 @@ class Model(object):
         -------
         collections.OrderedDict
         """
+        if self.is_integer:
+            raise ValueError("Dual values are not well-defined for integer problems")
         # Fallback, if nothing faster is available
         return collections.OrderedDict([(constraint.name, constraint.dual) for constraint in self.constraints])
 

--- a/optlang/interface.py
+++ b/optlang/interface.py
@@ -1222,8 +1222,6 @@ class Model(object):
         collections.OrderedDict
         """
         # Fallback, if nothing faster is available
-        if self.is_integer:
-            raise ValueError("Dual values are not well-defined for integer problems")
         return collections.OrderedDict([(variable.name, variable.dual) for variable in self.variables])
 
     @property
@@ -1245,8 +1243,6 @@ class Model(object):
         -------
         collections.OrderedDict
         """
-        if self.is_integer:
-            raise ValueError("Dual values are not well-defined for integer problems")
         # Fallback, if nothing faster is available
         return collections.OrderedDict([(constraint.name, constraint.dual) for constraint in self.constraints])
 

--- a/optlang/interface.py
+++ b/optlang/interface.py
@@ -1246,6 +1246,10 @@ class Model(object):
         # Fallback, if nothing faster is available
         return collections.OrderedDict([(constraint.name, constraint.dual) for constraint in self.constraints])
 
+    @property
+    def is_integer(self):
+        return any(var.type in ("integer", "binary") for var in self.variables)
+
     def __str__(self):
         if hasattr(self, "to_lp"):
             return self.to_lp()

--- a/optlang/tests/abstract_test_cases.py
+++ b/optlang/tests/abstract_test_cases.py
@@ -26,6 +26,7 @@ import json
 import copy
 import os
 import sympy
+from functools import partial
 
 __test__ = False
 
@@ -696,6 +697,57 @@ class AbstractModelTestCase(unittest.TestCase):
         self.assertEqual(c1.expression - (2 * x + y), 0)
         self.assertEqual(model.optimize(), optlang.interface.OPTIMAL)
         self.assertAlmostEqual(x.primal, 0.5)
+
+    def test_is_integer(self):
+        model = self.model
+        self.assertFalse(model.is_integer)
+
+        model.variables[0].type = "integer"
+        self.assertTrue(model.is_integer)
+
+        model.variables[0].type = "continuous"
+        model.variables[1].type = "binary"
+        self.assertTrue(model.is_integer)
+
+        model.variables[1].type = "continuous"
+        self.assertFalse(model.is_integer)
+
+    def test_integer_variable_dual(self):
+        model = self.interface.Model()
+        x = self.interface.Variable("x", lb=0)
+        y = self.interface.Variable("y", lb=0)
+        c = self.interface.Constraint(x + y, ub=1)
+        model.add(c)
+        model.objective = self.interface.Objective(x)
+
+        model.optimize()
+        self.assertEqual(y.dual, -1)
+
+        x.type = "integer"
+        model.optimize()
+        self.assertRaises(ValueError, partial(getattr, y, "dual"))
+
+        x.type = "continuous"
+        model.optimize()
+        self.assertEqual(y.dual, -1)
+
+    def test_integer_constraint_dual(self):
+        model = self.interface.Model()
+        x = self.interface.Variable("x")
+        c = self.interface.Constraint(x, ub=1)
+        model.add(c)
+        model.objective = self.interface.Objective(x)
+
+        model.optimize()
+        self.assertEqual(c.dual, 1)
+
+        x.type = "integer"
+        model.optimize()
+        self.assertRaises(ValueError, partial(getattr, c, "dual"))
+
+        x.type = "continuous"
+        model.optimize()
+        self.assertEqual(c.dual, 1)
 
 
 @six.add_metaclass(abc.ABCMeta)

--- a/optlang/tests/abstract_test_cases.py
+++ b/optlang/tests/abstract_test_cases.py
@@ -697,6 +697,57 @@ class AbstractModelTestCase(unittest.TestCase):
         self.assertEqual(model.optimize(), optlang.interface.OPTIMAL)
         self.assertAlmostEqual(x.primal, 0.5)
 
+    def test_is_integer(self):
+        model = self.model
+        self.assertFalse(model.is_integer)
+
+        model.variables[0].type = "integer"
+        self.assertTrue(model.is_integer)
+
+        model.variables[0].type = "continuous"
+        model.variables[1].type = "binary"
+        self.assertTrue(model.is_integer)
+
+        model.variables[1].type = "continuous"
+        self.assertFalse(model.is_integer)
+
+    def test_integer_variable_dual(self):
+        model = self.interface.Model()
+        x = self.interface.Variable("x", lb=0)
+        y = self.interface.Variable("y", lb=0)
+        c = self.interface.Constraint(x + y, ub=1)
+        model.add(c)
+        model.objective = self.interface.Objective(x)
+
+        model.optimize()
+        self.assertEqual(y.dual, -1)
+
+        x.type = "integer"
+        model.optimize()
+        self.assertEqual(y.dual, None)
+
+        x.type = "continuous"
+        model.optimize()
+        self.assertEqual(y.dual, -1)
+
+    def test_integer_constraint_dual(self):
+        model = self.interface.Model()
+        x = self.interface.Variable("x")
+        c = self.interface.Constraint(x, ub=1)
+        model.add(c)
+        model.objective = self.interface.Objective(x)
+
+        model.optimize()
+        self.assertEqual(c.dual, 1)
+
+        x.type = "integer"
+        model.optimize()
+        self.assertEqual(c.dual, None)
+
+        x.type = "continuous"
+        model.optimize()
+        self.assertEqual(c.dual, 1)
+
 
 @six.add_metaclass(abc.ABCMeta)
 class AbstractConfigurationTestCase(unittest.TestCase):

--- a/optlang/tests/abstract_test_cases.py
+++ b/optlang/tests/abstract_test_cases.py
@@ -697,57 +697,6 @@ class AbstractModelTestCase(unittest.TestCase):
         self.assertEqual(model.optimize(), optlang.interface.OPTIMAL)
         self.assertAlmostEqual(x.primal, 0.5)
 
-    def test_is_integer(self):
-        model = self.model
-        self.assertFalse(model.is_integer)
-
-        model.variables[0].type = "integer"
-        self.assertTrue(model.is_integer)
-
-        model.variables[0].type = "continuous"
-        model.variables[1].type = "binary"
-        self.assertTrue(model.is_integer)
-
-        model.variables[1].type = "continuous"
-        self.assertFalse(model.is_integer)
-
-    def test_integer_variable_dual(self):
-        model = self.interface.Model()
-        x = self.interface.Variable("x", lb=0)
-        y = self.interface.Variable("y", lb=0)
-        c = self.interface.Constraint(x + y, ub=1)
-        model.add(c)
-        model.objective = self.interface.Objective(x)
-
-        model.optimize()
-        self.assertEqual(y.dual, -1)
-
-        x.type = "integer"
-        model.optimize()
-        self.assertEqual(y.dual, None)
-
-        x.type = "continuous"
-        model.optimize()
-        self.assertEqual(y.dual, -1)
-
-    def test_integer_constraint_dual(self):
-        model = self.interface.Model()
-        x = self.interface.Variable("x")
-        c = self.interface.Constraint(x, ub=1)
-        model.add(c)
-        model.objective = self.interface.Objective(x)
-
-        model.optimize()
-        self.assertEqual(c.dual, 1)
-
-        x.type = "integer"
-        model.optimize()
-        self.assertEqual(c.dual, None)
-
-        x.type = "continuous"
-        model.optimize()
-        self.assertEqual(c.dual, 1)
-
 
 @six.add_metaclass(abc.ABCMeta)
 class AbstractConfigurationTestCase(unittest.TestCase):

--- a/optlang/tests/abstract_test_cases.py
+++ b/optlang/tests/abstract_test_cases.py
@@ -749,6 +749,31 @@ class AbstractModelTestCase(unittest.TestCase):
         model.optimize()
         self.assertEqual(c.dual, 1)
 
+    def test_integer_batch_duals(self):
+        model = self.interface.Model()
+        x = self.interface.Variable("x")
+        c = self.interface.Constraint(x, ub=1)
+        model.add(c)
+        model.objective = self.interface.Objective(x)
+        model.optimize()
+
+        self.assertEqual(model.reduced_costs[x.name], 0)
+        self.assertEqual(model.shadow_prices[c.name], 1)
+
+        x.type = "integer"
+        model.optimize()
+
+        with self.assertRaises(ValueError):
+            model.reduced_costs
+        with self.assertRaises(ValueError):
+            model.shadow_prices
+
+        x.type = "continuous"
+        model.optimize()
+
+        self.assertEqual(model.reduced_costs[x.name], 0)
+        self.assertEqual(model.shadow_prices[c.name], 1)
+
 
 @six.add_metaclass(abc.ABCMeta)
 class AbstractConfigurationTestCase(unittest.TestCase):

--- a/optlang/tests/test_cplex_interface.py
+++ b/optlang/tests/test_cplex_interface.py
@@ -357,6 +357,59 @@ else:
             self.model.objective = Objective(self.model.variables[2])
 
 
+        # TODO Move these 3 tests to AbstractTestCases
+        def test_is_integer(self):
+            model = self.model
+            self.assertFalse(model.is_integer)
+
+            model.variables[0].type = "integer"
+            self.assertTrue(model.is_integer)
+
+            model.variables[0].type = "continuous"
+            model.variables[1].type = "binary"
+            self.assertTrue(model.is_integer)
+
+            model.variables[1].type = "continuous"
+            self.assertFalse(model.is_integer)
+
+        def test_integer_variable_dual(self):
+            model = self.interface.Model()
+            x = self.interface.Variable("x", lb=0)
+            y = self.interface.Variable("y", lb=0)
+            c = self.interface.Constraint(x + y, ub=1)
+            model.add(c)
+            model.objective = self.interface.Objective(x)
+
+            model.optimize()
+            self.assertEqual(y.dual, -1)
+
+            x.type = "integer"
+            model.optimize()
+            self.assertEqual(y.dual, None)
+
+            x.type = "continuous"
+            model.optimize()
+            self.assertEqual(y.dual, -1)
+
+        def test_integer_constraint_dual(self):
+            model = self.interface.Model()
+            x = self.interface.Variable("x")
+            c = self.interface.Constraint(x, ub=1)
+            model.add(c)
+            model.objective = self.interface.Objective(x)
+
+            model.optimize()
+            self.assertEqual(c.dual, 1)
+
+            x.type = "integer"
+            model.optimize()
+            self.assertEqual(c.dual, None)
+
+            x.type = "continuous"
+            model.optimize()
+            self.assertEqual(c.dual, 1)
+
+
     class ConfigurationTestCase(abstract_test_cases.AbstractConfigurationTestCase):
         def setUp(self):
             self.model = Model()

--- a/optlang/tests/test_cplex_interface.py
+++ b/optlang/tests/test_cplex_interface.py
@@ -357,59 +357,6 @@ else:
             self.model.objective = Objective(self.model.variables[2])
 
 
-        # TODO Move these 3 tests to AbstractTestCases
-        def test_is_integer(self):
-            model = self.model
-            self.assertFalse(model.is_integer)
-
-            model.variables[0].type = "integer"
-            self.assertTrue(model.is_integer)
-
-            model.variables[0].type = "continuous"
-            model.variables[1].type = "binary"
-            self.assertTrue(model.is_integer)
-
-            model.variables[1].type = "continuous"
-            self.assertFalse(model.is_integer)
-
-        def test_integer_variable_dual(self):
-            model = self.interface.Model()
-            x = self.interface.Variable("x", lb=0)
-            y = self.interface.Variable("y", lb=0)
-            c = self.interface.Constraint(x + y, ub=1)
-            model.add(c)
-            model.objective = self.interface.Objective(x)
-
-            model.optimize()
-            self.assertEqual(y.dual, -1)
-
-            x.type = "integer"
-            model.optimize()
-            self.assertEqual(y.dual, None)
-
-            x.type = "continuous"
-            model.optimize()
-            self.assertEqual(y.dual, -1)
-
-        def test_integer_constraint_dual(self):
-            model = self.interface.Model()
-            x = self.interface.Variable("x")
-            c = self.interface.Constraint(x, ub=1)
-            model.add(c)
-            model.objective = self.interface.Objective(x)
-
-            model.optimize()
-            self.assertEqual(c.dual, 1)
-
-            x.type = "integer"
-            model.optimize()
-            self.assertEqual(c.dual, None)
-
-            x.type = "continuous"
-            model.optimize()
-            self.assertEqual(c.dual, 1)
-
-
     class ConfigurationTestCase(abstract_test_cases.AbstractConfigurationTestCase):
         def setUp(self):
             self.model = Model()

--- a/optlang/tests/test_scipy_interface.py
+++ b/optlang/tests/test_scipy_interface.py
@@ -297,3 +297,6 @@ class ModelTestCase(abstract_test_cases.AbstractModelTestCase):
 
     def test_integer_constraint_dual(self):
         self.skipTest("No duals with scipy")
+
+    def test_integer_batch_duals(self):
+        self.skipTest("No duals with scipy")

--- a/optlang/tests/test_scipy_interface.py
+++ b/optlang/tests/test_scipy_interface.py
@@ -288,3 +288,12 @@ class ModelTestCase(abstract_test_cases.AbstractModelTestCase):
         model.add(c)
         model.objective = obj
         self.assertEqual(model.optimize(), optlang.interface.OPTIMAL)
+
+    def test_is_integer(self):
+        self.skipTest()
+
+    def test_integer_variable_dual(self):
+        self.skipTest()
+
+    def test_integer_constraint_dual(self):
+        self.skipTest()

--- a/optlang/tests/test_scipy_interface.py
+++ b/optlang/tests/test_scipy_interface.py
@@ -290,10 +290,10 @@ class ModelTestCase(abstract_test_cases.AbstractModelTestCase):
         self.assertEqual(model.optimize(), optlang.interface.OPTIMAL)
 
     def test_is_integer(self):
-        self.skipTest()
+        self.skipTest("No integers with scipy")
 
     def test_integer_variable_dual(self):
-        self.skipTest()
+        self.skipTest("No duals with scipy")
 
     def test_integer_constraint_dual(self):
-        self.skipTest()
+        self.skipTest("No duals with scipy")


### PR DESCRIPTION
Chore: Raise a ValueError when trying to get constraint or variable dual values for an integer problem (instead of returning None)

Fix: Adds functionality to automatically change the type of the cplex problem when changing variable types