### PR TITLE
Fix for GLPK Constraint.get_linear_coefficients

### DIFF
--- a/optlang/glpk_interface.py
+++ b/optlang/glpk_interface.py
@@ -280,7 +280,12 @@ class Constraint(interface.Constraint):
             ia = intArray(num_cols + 1)
             da = doubleArray(num_cols + 1)
             nnz = glp_get_mat_row(self.problem.problem, self._index, ia, da)
-            return {self.problem._variables[ia[i + 1] - 1]: da[i + 1] for i in range(nnz)}
+            coefs = dict.fromkeys(variables, 0.0)
+            coefs.update({
+                self.problem._variables[ia[i + 1] - 1]: da[i + 1]
+                for i in range(nnz)
+                if self.problem._variables[ia[i + 1] - 1] in variables})
+            return coefs
         else:
             raise Exception("Can't get coefficients from solver if constraint is not in a model")
 


### PR DESCRIPTION
Fixes #99. Makes the function respect the `variables` arg instead of ignoring it.