### PR TITLE
feat: add a symbolic parameter [WIP fix #112]

### DIFF
--- a/optlang/__init__.py
+++ b/optlang/__init__.py
@@ -19,7 +19,7 @@ import logging
 import traceback
 from optlang._version import get_versions
 from optlang.util import list_available_solvers
-from optlang.interface import statuses
+from optlang.interface import statuses, SymbolicParameter
 import optlang.duality
 
 __version__ = get_versions()['version']

--- a/optlang/glpk_interface.py
+++ b/optlang/glpk_interface.py
@@ -25,10 +25,8 @@ To use GLPK you need to install the 'swiglpk' python package (with pip or from h
 and make sure that 'import swiglpk' runs without error.
 """
 
-import collections
 import logging
 
-import os
 import six
 
 from optlang.util import inheritdocstring, TemporaryFilename

--- a/optlang/interface.py
+++ b/optlang/interface.py
@@ -73,19 +73,6 @@ statuses = {
 }
 
 
-def evaluate_expression(expression):
-    return expression.subs([
-        (sym, sym.value) for sym in expression.free_symbols])
-
-
-def handle_symbols(expression, instance, attr):
-    if isinstance(expression, sympy.Expr):
-        for sym in expression.free_symbols:
-            sym.register(instance, attr, expression)
-        return evaluate_expression(expression)
-    return expression
-
-
 class SymbolicParameter(symbolics.Symbol):
     """
     A symbolic parameter to be used in bounds and constraints.
@@ -99,7 +86,7 @@ class SymbolicParameter(symbolics.Symbol):
 
     def __init__(self, name, value=0, **kwargs):
         super(SymbolicParameter, self).__init__(name=name, **kwargs)
-        self._stack = list()
+        self._registry = set()
         self._value = value
 
     @property
@@ -111,16 +98,51 @@ class SymbolicParameter(symbolics.Symbol):
     def value(self, other):
         """Set a new value and update all expressions."""
         self._value = other
-        for assigned, attr, expr in self._stack:
-            setattr(assigned, attr, evaluate_expression(expr))
 
-    def register(self, assigned, attr, expr):
+    def register(self, assigned, attr):
         """Register an object and its expression with this instance."""
-        self._stack.append((assigned, attr, expr))
+        self._registry.add((assigned, attr))
 
     def unregister(self, assigned):
         """Unregister an object from this instance."""
-        self._stack[:] = filter(lambda x: x[0] is not assigned, self._stack)
+        self._registry.remove(None)
+
+    @staticmethod
+    def handle_symbols(expression, instance, attr):
+        try:
+            for sym in expression.atoms(SymbolicParameter):
+                sym.register(instance, attr)
+            return SymbolicExpressionWrapper(expression)
+        except AttributeError:
+            return expression
+
+
+class SymbolicExpressionWrapper(object):
+    __slots__ = "_expression"
+
+    def __init__(self, expression):
+        super(SymbolicExpressionWrapper, self).__init__()
+        self._expression = expression
+
+    def __getattr__(self, name):
+        return self._expression.__getattr__(name)
+
+    def _evaluate(self):
+        return self._expression.subs([
+            (sym, sym.value) for sym in self._expression.atoms(
+                SymbolicParameter)])
+
+    def __float__(self):
+        return float(self._evaluate())
+
+    def __int__(self):
+        return int(self._evaluate())
+
+    def __repr__(self):
+        return repr(self._expression)
+
+    def __str__(self):
+        return str(self._expression)
 
 
 # noinspection PyShadowingBuiltins
@@ -211,8 +233,8 @@ class Variable(symbolics.Symbol):
                         name, char))
         self._name = name
         symbolics.Symbol.__init__(self, name, *args, **kwargs)
-        self._lb = lb
-        self._ub = ub
+        self._lb = SymbolicParameter.handle_symbols(lb, self, "lb")
+        self._ub = SymbolicParameter.handle_symbols(ub, self, "ub")
         if self._lb is None and type == 'binary':
             self._lb = 0.
         if self._ub is None and type == 'binary':
@@ -244,7 +266,7 @@ class Variable(symbolics.Symbol):
 
     @lb.setter
     def lb(self, value):
-        value = handle_symbols(value, self, "lb")
+        value = SymbolicParameter.handle_symbols(value, self, "lb")
         if hasattr(self, 'ub') and self.ub is not None and value is not None and value > self.ub:
             raise ValueError(
                 'The provided lower bound %g is larger than the upper bound %g of variable %s.' % (
@@ -261,7 +283,7 @@ class Variable(symbolics.Symbol):
 
     @ub.setter
     def ub(self, value):
-        value = handle_symbols(value, self, "ub")
+        value = SymbolicParameter.handle_symbols(value, self, "ub")
         if hasattr(self, 'lb') and self.lb is not None and value is not None and value < self.lb:
             raise ValueError(
                 'The provided upper bound %g is smaller than the lower bound %g of variable %s.' % (
@@ -712,7 +734,7 @@ class Constraint(OptimizationExpression):
 
     @lb.setter
     def lb(self, value):
-        value = handle_symbols(value, self, "lb")
+        value = SymbolicParameter.handle_symbols(value, self, "lb")
         self._check_valid_lower_bound(value)
         self._lb = value
 
@@ -723,7 +745,7 @@ class Constraint(OptimizationExpression):
 
     @ub.setter
     def ub(self, value):
-        value = handle_symbols(value, self, "ub")
+        value = SymbolicParameter.handle_symbols(value, self, "ub")
         self._check_valid_upper_bound(value)
         self._ub = value
 

--- a/symbolic.ipynb
+++ b/symbolic.ipynb
@@ -1,0 +1,270 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import six"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import optlang"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from optlang import Model, Variable, Constraint, Objective, SymbolicParameter"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from optlang.interface import SymbolicExpressionWrapper"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sympy.interactive.printing import init_printing\n",
+    "init_printing(use_latex=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAwAAAANBAMAAABvB5JxAAAALVBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAADAOrOgAAAADnRSTlMAIu92q4ndzZkQVLsyRLXs\nxoEAAAAJcEhZcwAADsQAAA7EAZUrDhsAAABUSURBVAgdY2BgVGBgdmBgYE1gYAtgYGBvYJi3gAGE\n101gAOF2BgaGNgaGVE4GhmwGxlfMDJzPGDgenmLgehFsYGrAwFEAlGdgYDIAU3IHwNQ1MAkAFsAQ\nTeSEcJcAAAAASUVORK5CYII=\n",
+      "text/latex": [
+       "$$\\mu$$"
+      ],
+      "text/plain": [
+       "μ"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mu = SymbolicParameter(\"mu\")\n",
+    "mu"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAAwAAAATBAMAAABW2/GaAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAImZ2VBCrMkS73e+Z\nzYkH3nCLAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAb0lEQVQIHWNgYGBgVBIAkgwmrOlAkqmAoRNI\nCTEweAEpAwaGNDDFsZGBgaPw0K0ABgZm1nengRr4gKwLQAwU/8DA0A7UuYGB4QEDA1sCAwNQXFqA\ngWESA/sKoHTR43cBYPVAk0DaQACoDQSA2oAAAKiiEbjlvkdEAAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$\\beta$$"
+      ],
+      "text/plain": [
+       "β"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "beta = SymbolicParameter(\"beta\", value=1)\n",
+    "beta"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "mu + 2"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "expr = SymbolicExpressionWrapper(mu + 2)\n",
+    "expr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAABkAAAAOBAMAAAAoFKpzAAAAMFBMVEX///8AAAAAAAAAAAAAAAAA\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAv3aB7AAAAD3RSTlMAEJm7MquJRO/dIs12\nVGbfGimAAAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAn0lEQVQIHT3NMQrCQBCF4X9BlMQUaazVXCHY\n5waxtUqwsDF3sLHQK9iY1s4bxMY+eIF0YicIKlbxDYILM7Mfs7zFRXGCneKqOaD7NvRrt4MxbEw3\nWMIWslKaQBNShWSJ9IRVrck+BPeQTkLvpearpSZvatIuzXWJVP+XwchkKY1SLvilFMM9pJMTmH6/\nHxbzGcMjXu3WULXtx2JdcU74AutiKKmrj+42AAAAAElFTkSuQmCC\n",
+      "text/latex": [
+       "$$2.0$$"
+      ],
+      "text/plain": [
+       "2.0"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "float(expr)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "optlang.interface.SymbolicExpressionWrapper"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "type(expr)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x1 = Variable('x1', lb=0 + mu)\n",
+    "x2 = Variable('x2', lb=0 + beta)\n",
+    "x3 = Variable('x3', lb=0 - mu)\n",
+    "c1 = Constraint(x1 + x2 + x3, lb=3, ub=100)\n",
+    "c2 = Constraint(10 * x1 + 4 * x2 + 5 * x3, lb=1, ub=600)\n",
+    "c3 = Constraint(2 * x1 + 2 *  x2 + 6 * x3, lb=2, ub=300)\n",
+    "obj = Objective(10 * x1 + 6 * x2 + 4 * x3, direction='max')\n",
+    "model = Model(name='Simple model')\n",
+    "model.objective = obj\n",
+    "model.add([c1, c2, c3])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "beta.value = 70"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "status: optimal\n",
+      "objective value: 733.3333333333333\n",
+      "x1 = 33.33333333333333\n",
+      "x2 = 66.66666666666667\n",
+      "x3 = 0.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "status = model.optimize()\n",
+    "print(\"status:\", model.status)\n",
+    "print(\"objective value:\", model.objective.value)\n",
+    "for var_name, var in six.iteritems(model.variables):\n",
+    "    print(var_name, \"=\", var.primal)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x2.lb = beta - 20"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "TypeError",
+     "evalue": "'<' not supported between instances of 'SymbolicExpressionWrapper' and 'SymbolicExpressionWrapper'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-16-675bdce7cb3c>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m()\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mx2\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mub\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mbeta\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m~/Codebase/Biosustain/optlang/optlang/glpk_interface.py\u001b[0m in \u001b[0;36mub\u001b[0;34m(self, value)\u001b[0m\n\u001b[1;32m     98\u001b[0m     \u001b[0;34m@\u001b[0m\u001b[0minterface\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mVariable\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mub\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0msetter\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     99\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mub\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mvalue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 100\u001b[0;31m         \u001b[0minterface\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mVariable\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mub\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfset\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mvalue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    101\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mproblem\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    102\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mproblem\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_glpk_set_col_bounds\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/Codebase/Biosustain/optlang/optlang/interface.py\u001b[0m in \u001b[0;36mub\u001b[0;34m(self, value)\u001b[0m\n\u001b[1;32m    285\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mub\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mvalue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    286\u001b[0m         \u001b[0mvalue\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mSymbolicParameter\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mhandle_symbols\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mvalue\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m\"ub\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 287\u001b[0;31m         \u001b[0;32mif\u001b[0m \u001b[0mhasattr\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'lb'\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mlb\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;32mNone\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mvalue\u001b[0m \u001b[0;32mis\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;32mNone\u001b[0m \u001b[0;32mand\u001b[0m \u001b[0mvalue\u001b[0m \u001b[0;34m<\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mlb\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    288\u001b[0m             raise ValueError(\n\u001b[1;32m    289\u001b[0m                 'The provided upper bound %g is smaller than the lower bound %g of variable %s.' % (\n",
+      "\u001b[0;31mTypeError\u001b[0m: '<' not supported between instances of 'SymbolicExpressionWrapper' and 'SymbolicExpressionWrapper'"
+     ]
+    }
+   ],
+   "source": [
+    "x2.ub = beta"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
* Add a class `SymbolicParameter` which inherits from `symbolics.Symbol`.
* Integrate the new symbolic parameter with the lower and upper bounds of
  `Variable` and `Constraint`.

I'm fairly happy with the current design although there are certainly still a number of decisions to be made. First of all, do symbolic expressions on variable and constraint bounds cover all the use cases? I guess, at least the objective should also be possible. Should the expressions of constraints themselves be able to contain symbolic parameters?

In the `SymbolicParameter` class I provide a method `unregister` which should be integrated with the variables and constraints. Maybe `Variable` and `Constraint` should get a memory for all the `SymbolicParameter`s that they depend on and then we can call `unregister` in their `__del__` method?