### PR TITLE
Fix constraint primal calculation in gurobi interface

### DIFF
--- a/optlang/gurobi_interface.py
+++ b/optlang/gurobi_interface.py
@@ -238,7 +238,8 @@ class Constraint(interface.Constraint):
     @property
     def primal(self):
         if self.problem is not None:
-            return self._internal_constraint.Slack
+            return (self._internal_constraint.RHS -
+                    self._internal_constraint.Slack)
             # return self._round_primal_to_bounds(primal_from_solver)  # Test assertions fail
             # return primal_from_solver
         else:


### PR DESCRIPTION
Now gives the correct primals for the constraint expression:

```Python
In [1]: import optlang

In [2]: gurobi = optlang.gurobi_interface

In [3]: mod = gurobi.Model()
Academic license - for non-commercial use only

In [4]: x = gurobi.Variable(lb=3, ub=3, name="x")

In [5]: const = gurobi.Constraint(x, lb=3)

In [6]: mod.add([x, const])

In [7]: mod.optimize()
Out[7]: 'optimal'

In [8]: x.primal
Out[8]: 3.0

In [9]: const.primal
Out[9]: 3.0
```

Fixes #115.