### PR TITLE
Fix uncaught error when requesting invalidated objective

### DIFF
--- a/optlang/gurobi_interface.py
+++ b/optlang/gurobi_interface.py
@@ -329,7 +329,7 @@ class Objective(interface.Objective):
         if getattr(self, "problem", None) is not None:
             try:
                 return self.problem.problem.getAttr("ObjVal") + getattr(self.problem, "_objective_offset", 0)
-            except gurobipy.GurobiError:  # TODO: let this check the actual error message
+            except (gurobipy.GurobiError, AttributeError):  # TODO: let this check the actual error message
                 return None
         else:
             return None


### PR DESCRIPTION
Newer Gurobi version throw an `AttributeError` and not a `GurobiError`.

The following now works as intended:

```Python
In [1]: import optlang

In [2]: gurobi = optlang.gurobi_interface

In [3]: mod = gurobi.Model()
Academic license - for non-commercial use only

In [4]: v = gurobi.Variable(name="v", lb=0, ub=3)

In [5]: mod.objective = gurobi.Objective(v, direction="max")

In [6]: mod.optimize()
Out[6]: 'optimal'

In [7]: mod.objective.value
Out[7]: 3.0

In [8]: v.lb = 1

In [9]: mod.objective.value is None
Out[9]: True
```

Before the fix the last statement would throw an AttributeError.