### PR TITLE
fix: ensure that variable names are not empty str

### DIFF
--- a/optlang/interface.py
+++ b/optlang/interface.py
@@ -181,6 +181,9 @@ class Variable(sympy.Symbol):
         if six.PY2:
             name = str(name)
 
+        if len(name) < 1:
+            raise ValueError('Variable name must not be empty string')
+
         for char in name:
             if char.isspace():
                 raise ValueError(

--- a/optlang/tests/test_interface.py
+++ b/optlang/tests/test_interface.py
@@ -167,6 +167,9 @@ class TestVariable(TestCase):
     def setUp(self):
         self.x = Variable("x")
 
+    def test_init_variable(self):
+        self.assertRaises(ValueError, Variable, '')
+
     def test_set_wrong_bounds_on_binary_raises(self):
         self.assertRaises(ValueError, Variable, 'x', lb=-33, ub=0.3, type='binary')
         x = Variable('x', type='binary')


### PR DESCRIPTION
Variables with empty names trigger's segfaults in glpk
interface. Easiest fix appears to simply not allow them as anyway not
meaningful.