### PR TITLE
Add basic types to optlang.symbolics

### DIFF
--- a/optlang/symbolics.py
+++ b/optlang/symbolics.py
@@ -86,12 +86,14 @@ if USE_SYMENGINE:  # pragma: no cover
     def add(*args):
         if len(args) == 1:
             args = args[0]
-        return sum(args)
+        return Add(*args)
 
     def mul(*args):
         if len(args) == 1:
             args = args[0]
-        return reduce(operator.mul, args, 1)
+        if len(args) == 0:
+            return(Zero)
+        return reduce(operator.mul, args, One)
 
 else:  # Use sympy
     import sympy

--- a/optlang/symbolics.py
+++ b/optlang/symbolics.py
@@ -92,7 +92,7 @@ if USE_SYMENGINE:  # pragma: no cover
         if len(args) == 1:
             args = args[0]
         if len(args) == 0:
-            return(Zero)
+            return(Zero)  # if you multiply nothing the result should be zero
         return reduce(operator.mul, args, One)
 
 else:  # Use sympy
@@ -103,6 +103,8 @@ else:  # Use sympy
 
     Integer = sympy.Integer
     Real = sympy.RealNumber
+    Basic = sympy.Basic
+    Number = sympy.Number
     Zero = Integer(0)
     One = Integer(1)
     NegativeOne = Integer(-1)

--- a/optlang/symbolics.py
+++ b/optlang/symbolics.py
@@ -55,6 +55,8 @@ if USE_SYMENGINE:  # pragma: no cover
 
     Integer = symengine.Integer
     Real = symengine.RealDouble
+    Basic = symengine.Basic
+    Number = symengine.Number
     Zero = Integer(0)
     One = Integer(1)
     NegativeOne = Integer(-1)


### PR DESCRIPTION
This adds the `Basic` and `Number` types to `optlang.symbolics`. This is needed in order to remain compatible with cobrapy.

Thanks! 