### PR TITLE
repair symbolics.mul for symengine

### DIFF
--- a/optlang/symbolics.py
+++ b/optlang/symbolics.py
@@ -95,7 +95,7 @@ if USE_SYMENGINE:  # pragma: no cover # noqa: C901
             args = args[0]
         elif len(args) == 0:
             return One  # if you multiply nothing the result should be zero
-        return Mul(args)
+        return Mul(*args)
 
 else:  # Use sympy
     import sympy


### PR DESCRIPTION
There is a small error (missing unpacking of the args) which will cause `symbolics.mul` to fail for basically any input.