### PR TITLE
fix: make releases from only one Python version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,6 @@ notifications:
   slack:
     secure: s8Dj0MFreNwZ3Zhb0+5yJiHPL33JsxLjmoRo8f0ohLdD15L//E4VjkCsYkNEcLzid6HarEL/1JSmzAuGl40fCdLqTAoDRy01shT1zmfWQPXQlaALh5f8ExBAlyDHxKhd/B2SytYu6uhe0WOuxu/oo4c33a7pKhuV1piNcevPZew=
 before_deploy:
-  - pip install twine
   - python setup.py sdist bdist_wheel
 deploy:
   - provider: releases
@@ -62,6 +61,7 @@ deploy:
       repo: $GITHUB_REPO
       python: '3.6'
   - provider: pypi
+    distributions: sdist bdist_wheel
     user: Nikolaus.Sonnenschein
     password:
       secure: Gn23MUvzP1DPJXxRXUOXGBJjyMamawxey5ByrOd+JT90roljHKSk8v1wdBMH7+s1DB/ygUJqB2Zy0cBC3mr0waY6HmxKpXhddgzQzG56Eua/npTxpz58Y8xfSYF+5QqS3gcyBrYEXmeHWuEURERy0b7uYKMx/QcHAHYhTaVy4zE=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,17 @@
 language: python
 sudo: false
+git:
+  depth: 1
 python:
   - '2.7'
   - '3.4'
   - '3.5'
   - '3.6'
+branches:
+  only:
+  - master
+  - devel
+  - "/^\\d+\\.\\d+\\.\\d+[a]?\\d*$/"
 env:
   global:
     - GITHUB_REPO=biosustain/optlang

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,16 @@ python:
   - '2.7'
   - '3.4'
   - '3.5'
+  - '3.6'
 env:
   global:
+    - GITHUB_REPO=biosustain/optlang
     - secure: PBcwrLg4ZwVi9Gw25Q2adNd0uK+NCqFSiYl+ZuumkEXs4NQBbSXVd719wrWKUFdIqBy+h9ETo4Vsz/QsTZzI2mSG4zqTkm+oUxMW1tJxYEeKZvCo7GfZ883VlKFgdqvh6iouEvHSjfGbwc5cUp98CbjgI5ni01vGpDQh2hgokkI=
   matrix:
     - OPTLANG_USE_SYMENGINE=False
     - OPTLANG_USE_SYMENGINE=True
+matrix:
+  fast_finish: true
 cache:
   - pip: true
 addons:
@@ -54,14 +58,14 @@ deploy:
     file: dist/optlang*.whl
     skip_cleanup: true
     on:
-      branch: master
       tags: true
-      repo: biosustain/optlang
+      repo: $GITHUB_REPO
+      python: '3.6'
   - provider: pypi
     user: Nikolaus.Sonnenschein
     password:
       secure: Gn23MUvzP1DPJXxRXUOXGBJjyMamawxey5ByrOd+JT90roljHKSk8v1wdBMH7+s1DB/ygUJqB2Zy0cBC3mr0waY6HmxKpXhddgzQzG56Eua/npTxpz58Y8xfSYF+5QqS3gcyBrYEXmeHWuEURERy0b7uYKMx/QcHAHYhTaVy4zE=
     on:
-      branch: master
       tags: true
-      repo: biosustain/optlang
+      repo: $GITHUB_REPO
+      python: '3.6'

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
   - export SYMPY_USE_CACHE=no
   - pip install pip --upgrade
   - 'echo "this is a build for: $TRAVIS_BRANCH"'
-  - 'if [[ "$TRAVIS_PYTHON_VERSION" != "3.5" ]]; then bash ./.travis/install_cplex.sh; fi'
+  - 'if [[ "$TRAVIS_PYTHON_VERSION" < "3.5" ]]; then bash ./.travis/install_cplex.sh; fi'
 install:
   - pip install nose nose-progressive rednose coverage docutils flake8 codecov jsonschema
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,15 +16,6 @@ matrix:
   fast_finish: true
 cache:
   - pip: true
-addons:
-  apt:
-    packages:
-    - swig
-    - libzmq3-dev
-    - libgmp-dev
-    - libglpk-dev
-    - glpk-utils
-    - pandoc
 before_install:
   - export SYMPY_USE_CACHE=no
   - pip install pip --upgrade
@@ -33,11 +24,8 @@ before_install:
 install:
   - pip install nose nose-progressive rednose coverage docutils flake8 codecov jsonschema
   - pip install -r requirements.txt
-  - pip install inspyred
-  - pip install pypandoc
-  - pip install swiglpk
   - pip install scipy
-  - pip install symengine
+  - 'if [[ "$OPTLANG_USE_SYMENGINE" = "True" ]]; then pip install symengine; fi'
   - python setup.py install
 before_script:
   - flake8 .
@@ -47,20 +35,18 @@ after_success:
 notifications:
   slack:
     secure: s8Dj0MFreNwZ3Zhb0+5yJiHPL33JsxLjmoRo8f0ohLdD15L//E4VjkCsYkNEcLzid6HarEL/1JSmzAuGl40fCdLqTAoDRy01shT1zmfWQPXQlaALh5f8ExBAlyDHxKhd/B2SytYu6uhe0WOuxu/oo4c33a7pKhuV1piNcevPZew=
-before_deploy:
-  - python setup.py sdist bdist_wheel
 deploy:
   - provider: releases
     api_key:
       secure: u4aJv+5YoH3gjJpyiVoq33SqKIUtx8LWPp15pIh8hKHmUgJNyjGm7ELXOeczfQ5W7ZpnWj+ogewaes2oA0NLxBB1/MBPL7kr77hmzp+XhZomh73DzFKegbpBTgqpioBRxvPlq3HYNIWqrLkeg/HYlBW1WM6mKifFUwqbIaL+++4=
-    file_glob: true
-    file: dist/optlang*.whl
     skip_cleanup: true
     on:
       tags: true
       repo: $GITHUB_REPO
       python: '3.6'
+      condition: $OPTLANG_USE_SYMENGINE = False
   - provider: pypi
+    skip_cleanup: true
     distributions: sdist bdist_wheel
     user: Nikolaus.Sonnenschein
     password:
@@ -69,3 +55,4 @@ deploy:
       tags: true
       repo: $GITHUB_REPO
       python: '3.6'
+      condition: $OPTLANG_USE_SYMENGINE = False

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,9 @@
+branches:
+ only:
+ - master
+ - devel
+ - "/^\\d+\\.\\d+\\.\\d+[a]?\\d*$/"
+
 environment:
   global:
     # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
@@ -19,7 +25,7 @@ environment:
       PYTHON_VERSION: "3.5.2"
       PYTHON_ARCH: "64"
 
-clone_depth: 25
+clone_depth: 2
 
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%bit"


### PR DESCRIPTION
* Add Python 3.6 to tested versions.
* Abort testing as soon as one test fails (`fast_finish`).
* Add the Python version to the conditions such that only one deployment is attempted.