### PR TITLE
Fix name issues

### DIFF
--- a/optlang/glpk_interface.py
+++ b/optlang/glpk_interface.py
@@ -74,11 +74,17 @@ _VTYPE_TO_GLPK_VTYPE = dict(
 )
 
 
+def _glpk_validate_id(name):
+    if name is None:
+        return
+    if len(name) > 256:
+        raise ValueError("GLPK does not support ID's longer than 256 characters")
+
+
 @six.add_metaclass(inheritdocstring)
 class Variable(interface.Variable):
     def __init__(self, name, index=None, *args, **kwargs):
-        if len(name) > 256:
-            raise ValueError("GLPK does not support ID's longer than 256 characters")
+        _glpk_validate_id(name)
         super(Variable, self).__init__(name, **kwargs)
 
     @property
@@ -141,8 +147,7 @@ class Variable(interface.Variable):
 
     @interface.Variable.name.setter
     def name(self, value):
-        if len(value) > 256:
-            raise ValueError("GLPK does not support ID's longer than 256 characters")
+        _glpk_validate_id(value)
         if getattr(self, 'problem', None) is not None:
             glp_set_col_name(self.problem.problem, glp_find_col(self.problem.problem, self.name), str(value))
         super(Variable, Variable).name.fset(self, value)
@@ -153,8 +158,7 @@ class Constraint(interface.Constraint):
     _INDICATOR_CONSTRAINT_SUPPORT = False
 
     def __init__(self, expression, sloppy=False, *args, **kwargs):
-        if len(kwargs.get("name", "")) > 256:
-            raise ValueError("GLPK does not support ID's longer than 256 characters")
+        _glpk_validate_id(kwargs.get("name", "GoodName"))
         super(Constraint, self).__init__(expression, sloppy=sloppy, *args, **kwargs)
         if not sloppy:
             if not self.is_Linear:
@@ -189,8 +193,7 @@ class Constraint(interface.Constraint):
 
     @interface.OptimizationExpression.name.setter
     def name(self, value):
-        if len(value) > 256:
-            raise ValueError("GLPK does not support ID's longer than 256 characters")
+        _glpk_validate_id(value)
         old_name = getattr(self, 'name', None)
         self._name = value
         if self.problem is not None:
@@ -486,8 +489,7 @@ class Model(interface.Model):
             self.problem = glp_create_prob()
             glp_create_index(self.problem)
             if self.name is not None:
-                if len(self.name) > 256:
-                    raise ValueError("GLPK does not support ID's longer than 256 characters")
+                _glpk_validate_id(self.name)
                 glp_set_prob_name(self.problem, str(self.name))
 
         else:

--- a/optlang/interface.py
+++ b/optlang/interface.py
@@ -133,6 +133,19 @@ class Variable(symbolics.Symbol):
             raise ValueError(
                 'The provided upper bound %s cannot be assigned to binary variable %s.' % (value, name))
 
+    @staticmethod
+    def __validate_variable_name(name):
+        if name is None:
+            return
+        if len(name) < 1:
+            raise ValueError('Variable name must not be empty string')
+        for char in name:
+            if char.isspace():
+                raise ValueError(
+                    'Variable names cannot contain whitespace characters. "%s" contains whitespace character "%s".' % (
+                        name, char)
+                )
+
     @classmethod
     def clone(cls, variable, **kwargs):
         """
@@ -147,18 +160,12 @@ class Variable(symbolics.Symbol):
 
     def __init__(self, name, lb=None, ub=None, type="continuous", problem=None, *args, **kwargs):
 
-        # Ensure that name is str and not binary of unicode - some solvers only support string type in Python 2.
+        # Ensure that name is str and not unicode - some solvers only support string type in Python 2.
         if six.PY2:
             name = str(name)
 
-        if len(name) < 1:
-            raise ValueError('Variable name must not be empty string')
+        self.__validate_variable_name(name)
 
-        for char in name:
-            if char.isspace():
-                raise ValueError(
-                    'Variable names cannot contain whitespace characters. "%s" contains whitespace character "%s".' % (
-                        name, char))
         self._name = name
         symbolics.Symbol.__init__(self, name, *args, **kwargs)
         self._lb = lb
@@ -180,6 +187,7 @@ class Variable(symbolics.Symbol):
 
     @name.setter
     def name(self, value):
+        self.__validate_variable_name(value)
         old_name = getattr(self, 'name', None)
         self._name = value
         if getattr(self, 'problem', None) is not None and value != old_name:
@@ -367,6 +375,19 @@ class Variable(symbolics.Symbol):
 class OptimizationExpression(object):
     """Abstract base class for Objective and Constraint."""
 
+    @staticmethod
+    def _validate_optimization_expression_name(name):
+        if name is None:
+            return
+        if len(name) < 1:
+            raise ValueError('Variable name must not be empty string')
+        for char in name:
+            if char.isspace():
+                raise ValueError(
+                    'Variable names cannot contain whitespace characters. "%s" contains whitespace character "%s".' % (
+                        name, char)
+                )
+
     @classmethod
     def _substitute_variables(cls, expression, model=None, **kwargs):
         """Substitutes variables in (optimization)expression (constraint/objective) with variables of the appropriate interface type.
@@ -389,9 +410,11 @@ class OptimizationExpression(object):
         return adjusted_expression
 
     def __init__(self, expression, name=None, problem=None, sloppy=False, *args, **kwargs):
-        # Ensure that name is str and not binary of unicode - some solvers only support string type in Python 2.
+        # Ensure that name is str and not unicode - some solvers only support string type in Python 2.
         if six.PY2 and name is not None:
             name = str(name)
+
+        self._validate_optimization_expression_name(name)
 
         super(OptimizationExpression, self).__init__(*args, **kwargs)
         self._problem = problem
@@ -411,6 +434,7 @@ class OptimizationExpression(object):
 
     @name.setter
     def name(self, value):
+        self._validate_optimization_expression_name(value)
         self._name = value
 
     @property


### PR DESCRIPTION
GLPK could not copy models if constraint names included spaces. Furthermore GLPK would crash (Abort trap: 6) if names were empty strings or non-space whitespace (tabs, newlines)

For all solvers the following restrictions now apply:
- Names can’t contain whitespace
- Names can’t be empty strings

Additionally for GLPK:
- Names can’t be more than 256 characters
