### PR TITLE
refactor: make base constants real numbers

### DIFF
--- a/optlang/expression_parsing.py
+++ b/optlang/expression_parsing.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from optlang.symbolics import One
+from optlang.symbolics import Integer
 
 
 def parse_optimization_expression(obj, linear=True, quadratic=False, expression=None, **kwargs):
@@ -70,6 +70,7 @@ def _parse_linear_expression(expression, expanded=False, **kwargs):
     """
     offset = 0
     constant = None
+    one = Integer(1)
 
     if expression.is_Add:
         coefficients = expression.as_coefficients_dict()
@@ -84,7 +85,7 @@ def _parse_linear_expression(expression, expanded=False, **kwargs):
 
     for var in coefficients:
         if not (var.is_Symbol):
-            if var == One:
+            if var == one:
                 constant = var
                 offset = float(coefficients[var])
             elif expanded:

--- a/optlang/expression_parsing.py
+++ b/optlang/expression_parsing.py
@@ -15,6 +15,8 @@
 
 from optlang.symbolics import Integer
 
+one = Integer(1)
+
 
 def parse_optimization_expression(obj, linear=True, quadratic=False, expression=None, **kwargs):
     """
@@ -70,7 +72,6 @@ def _parse_linear_expression(expression, expanded=False, **kwargs):
     """
     offset = 0
     constant = None
-    one = Integer(1)
 
     if expression.is_Add:
         coefficients = expression.as_coefficients_dict()

--- a/optlang/scipy_interface.py
+++ b/optlang/scipy_interface.py
@@ -418,6 +418,7 @@ class Constraint(interface.Constraint):
         if self.expression.is_Add:
             coefficient_dict = {variable: coef for variable, coef in
                                 self.expression.as_coefficients_dict().items() if variable.is_Symbol}
+            coefficient_dict = {var: float(coef) for var, coef in coefficient_dict.items()}
         elif self.expression.is_Atom and self.expression.is_Symbol:
             coefficient_dict = {self.expression: 1}
         elif self.expression.is_Mul and len(self.expression.args) <= 2:
@@ -496,7 +497,7 @@ class Objective(interface.Objective):
             coefficient_dict = {}
         else:
             raise ValueError("Invalid expression: " + str(self.expression))
-        coefficient_dict = {var.name: coef for var, coef in coefficient_dict.items()}
+        coefficient_dict = {var.name: float(coef) for var, coef in coefficient_dict.items()}
         return coefficient_dict
 
     def set_linear_coefficients(self, coefficients):
@@ -509,7 +510,7 @@ class Objective(interface.Objective):
     def get_linear_coefficients(self, variables):
         if self.problem is not None:
             self.problem.update()
-            return {v: self.problem.problem.objective.get(v.name, 0) for v in variables}
+            return {v: float(self.problem.problem.objective.get(v.name, 0)) for v in variables}
         else:
             raise Exception("Can't get coefficients from solver if objective is not in a model")
 

--- a/optlang/symbolics.py
+++ b/optlang/symbolics.py
@@ -58,9 +58,9 @@ if USE_SYMENGINE:  # pragma: no cover # noqa: C901
     Real = symengine.RealDouble
     Basic = symengine.Basic
     Number = symengine.Number
-    Zero = Integer(0)
-    One = Integer(1)
-    NegativeOne = Integer(-1)
+    Zero = Real(0)
+    One = Real(1)
+    NegativeOne = Real(-1)
     sympify = symengine.sympy_compat.sympify
 
     Add = symengine.Add
@@ -113,9 +113,9 @@ else:  # Use sympy
     Real = sympy.RealNumber
     Basic = sympy.Basic
     Number = sympy.Number
-    Zero = Integer(0)
-    One = Integer(1)
-    NegativeOne = Integer(-1)
+    Zero = Real(0)
+    One = Real(1)
+    NegativeOne = Real(-1)
     sympify = sympy.sympify
 
     Add = sympy.Add

--- a/optlang/tests/abstract_test_cases.py
+++ b/optlang/tests/abstract_test_cases.py
@@ -20,6 +20,7 @@ import unittest
 
 import six
 from optlang import interface
+from optlang import symbolics
 import optlang
 import pickle
 import json
@@ -350,6 +351,18 @@ class AbstractConstraintTestCase(unittest.TestCase):
         with self.assertRaises(Exception):
             const.name = "This\ttab"
 
+    def test_construct_with_sloppy(self):
+        x, y, z, w = self.model.variables[:4]
+        const = self.interface.Constraint(
+            symbolics.add([symbolics.mul(symbolics.One, var) for var in [x, y, z]]),
+            lb=0,
+            sloppy=True
+        )
+        self.model.add(const)
+        self.model.update()
+
+        self.assertTrue(const.get_linear_coefficients([x, y, z, w]) == {x: 1, y: 1, z: 1, w: 0})
+
 
 @six.add_metaclass(abc.ABCMeta)
 class AbstractObjectiveTestCase(unittest.TestCase):
@@ -389,6 +402,17 @@ class AbstractObjectiveTestCase(unittest.TestCase):
             obj.name = "This space"
         with self.assertRaises(Exception):
             obj.name = "This\ttab"
+
+    def test_construct_with_sloppy(self):
+        x, y, z, w = self.model.variables[:4]
+        obj = self.interface.Objective(
+            symbolics.add([symbolics.mul((symbolics.One, var)) for var in [x, y, z]]),
+            direction="min",
+            sloppy=True
+        )
+        self.model.objective = obj
+
+        self.assertTrue(obj.get_linear_coefficients([x, y, z, w]) == {x: 1, y: 1, z: 1, w: 0})
 
 
 @six.add_metaclass(abc.ABCMeta)

--- a/optlang/tests/test_symbolics.py
+++ b/optlang/tests/test_symbolics.py
@@ -5,7 +5,7 @@ import optlang
 class SymbolicsTestCase(unittest.TestCase):
 
     def test_add_identity(self):
-        self.assertEqual(optlang.symbolics.add(), 0)
+        self.assertEqual(optlang.symbolics.add(), 0.0)
 
     def test_mul_identity(self):
-        self.assertEqual(optlang.symbolics.mul(), 1)
+        self.assertEqual(optlang.symbolics.mul(), 1.0)


### PR DESCRIPTION
Using real numbers avoids certain corner cases where integers are either
undesired, e.g., in `set_linear_coefficients` or they would be
simplified out as in `Mul(One, variable)`.