### PR TITLE
fix: broken rtfd build due to numpydoc getting old

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -29,7 +29,7 @@ sys.path.insert(0, os.path.abspath('../../'))
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.todo', 'sphinx.ext.coverage',
-              'sphinx.ext.mathjax', 'sphinx.ext.ifconfig', 'sphinx.ext.viewcode', 'numpydoc']
+              'sphinx.ext.mathjax', 'sphinx.ext.ifconfig', 'sphinx.ext.viewcode', 'sphinx.ext.napoleon']
 
 mathjax_path = "https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"
 

--- a/requirements_rtd.txt
+++ b/requirements_rtd.txt
@@ -1,3 +1,1 @@
 sphinx-rtd-theme>=0.1.6
-numpydoc==0.5
-sympy==0.7.5


### PR DESCRIPTION
Replaced numpydoc with napoleon (which comes prepackaged with sphinx now). Did the fix based on this issue here https://github.com/rtfd/readthedocs.org/issues/4057.