### PR TITLE
Set cplex problem logger name

### DIFF
--- a/optlang/cplex_interface.py
+++ b/optlang/cplex_interface.py
@@ -470,7 +470,7 @@ class Configuration(interface.MathematicalProgrammingConfiguration):
             def flush(self):
                 self.logger.debug(self.getvalue())
 
-        logger = logging.getLogger()
+        logger = logging.getLogger('cplex.problem')
         logger.setLevel(logging.CRITICAL)
         error_stream_handler = ErrorStreamHandler(logger)
         warning_stream_handler = WarningStreamHandler(logger)


### PR DESCRIPTION
The current behaviour will overwrite the root logger level of any application using optlang together with cplex (in practice silence most log output and confuse developers). This fix creates a logger with an explicit name instead of using root. I chose `cplex.problem` instead of `__name__` since it's not actually a logger for the current module; not 100% sure what the best name is though.