### PR TITLE
Don't use deprecated `logging.warn` method

### DIFF
--- a/optlang/cplex_interface.py
+++ b/optlang/cplex_interface.py
@@ -458,7 +458,7 @@ class Configuration(interface.MathematicalProgrammingConfiguration):
         class WarningStreamHandler(StreamHandler):
 
             def flush(self):
-                self.logger.warn(self.getvalue())
+                self.logger.warning(self.getvalue())
 
         class LogStreamHandler(StreamHandler):
 


### PR DESCRIPTION
The deprecation warnings are creating some noise in our applications :)