### PR TITLE
Conserve tolerances in GLPK when pickling

### DIFF
--- a/optlang/cplex_interface.py
+++ b/optlang/cplex_interface.py
@@ -528,7 +528,7 @@ class Configuration(interface.MathematicalProgrammingConfiguration):
                 "tolerances": {"feasibility": self.tolerances.feasibility,
                                "optimality": self.tolerances.optimality,
                                "integrality": self.tolerances.integrality}
-               }
+                }
 
     def __setstate__(self, state):
         for key, val in six.iteritems(state):

--- a/optlang/cplex_interface.py
+++ b/optlang/cplex_interface.py
@@ -403,6 +403,9 @@ class Configuration(interface.MathematicalProgrammingConfiguration):
         self.timeout = timeout
         self.solution_target = solution_target
         self.qp_method = qp_method
+        if "tolerances" in kwargs:
+            for key, val in six.iteritems(kwargs["tolerances"]):
+                setattr(self.tolerances, key, val)
 
     @property
     def lp_method(self):
@@ -519,11 +522,18 @@ class Configuration(interface.MathematicalProgrammingConfiguration):
         self._timeout = value
 
     def __getstate__(self):
-        return {"presolve": self.presolve, "timeout": self.timeout, "verbosity": self.verbosity}
+        return {"presolve": self.presolve,
+                "timeout": self.timeout,
+                "verbosity": self.verbosity,
+                "tolerances": {"feasibility": self.tolerances.feasibility,
+                               "optimality": self.tolerances.optimality,
+                               "integrality": self.tolerances.integrality}
+               }
 
     def __setstate__(self, state):
         for key, val in six.iteritems(state):
-            setattr(self, key, val)
+            if key != "tolerances":
+                setattr(self, key, val)
 
     @property
     def solution_target(self):

--- a/optlang/glpk_interface.py
+++ b/optlang/glpk_interface.py
@@ -392,14 +392,24 @@ class Configuration(interface.MathematicalProgrammingConfiguration):
         self.presolve = presolve
         self.verbosity = verbosity
         self.timeout = timeout
+        if "tolerances" in kwargs:
+            for key, val in six.iteritems(kwargs["tolerances"]):
+                setattr(self.tolerances, key, val)
 
     def __getstate__(self):
-        return {'presolve': self.presolve, 'verbosity': self.verbosity, 'timeout': self.timeout}
+        return {'presolve': self.presolve,
+                'verbosity': self.verbosity,
+                'timeout': self.timeout,
+                'tolerances': {"feasibility": self.tolerances.feasibility}
+               }
 
     def __setstate__(self, state):
         self.__init__()
         for key, val in six.iteritems(state):
-            setattr(self, key, val)
+            if key != "tolerances":
+                setattr(self, key, val)
+        for key, val in six.iteritems(state["tolerances"]):
+            setattr(self.tolerances, key, val)
 
     def _set_presolve(self, value):
         self._smcp.presolve = {False: GLP_OFF, True: GLP_ON, "auto": GLP_OFF}[value]
@@ -436,21 +446,16 @@ class Configuration(interface.MathematicalProgrammingConfiguration):
             self._smcp.tm_lim = value * 1000  # milliseconds to seconds
             self._iocp.tm_lim = value * 1000
 
+    def _get_feasibility(self):
+        return getattr(self._smcp, "tol_bnd")
+
+    def _set_feasibility(self, value):
+        return setattr(self._smcp, "tol_bnd", value)
+
     def _tolerance_functions(self):
         return {
-            "feasibility": (
-                lambda: self._smcp.tol_bnd,
-                lambda x: setattr(self._smcp, 'tol_bnd', x)
-            ),
-            "optimality": (
-                lambda: self._iocp.tol_obj,
-                lambda x: setattr(self._iocp, 'tol_obj', x)
-            ),
-            "integrality": (
-                lambda: self._iocp.tol_int,
-                lambda x: setattr(self._iocp, 'tol_int', x)
-            )
-        }
+            "feasibility": (self._get_feasibility, self._set_feasibility)
+            }
 
     @property
     def presolve(self):

--- a/optlang/glpk_interface.py
+++ b/optlang/glpk_interface.py
@@ -401,7 +401,7 @@ class Configuration(interface.MathematicalProgrammingConfiguration):
                 'verbosity': self.verbosity,
                 'timeout': self.timeout,
                 'tolerances': {"feasibility": self.tolerances.feasibility}
-               }
+                }
 
     def __setstate__(self, state):
         self.__init__()

--- a/optlang/interface.py
+++ b/optlang/interface.py
@@ -985,6 +985,8 @@ class Configuration(object):
         properties = (k for k, v in inspect.getmembers(cls, predicate=inspect.isdatadescriptor) if
                       not k.startswith('__'))
         parameters = {property: getattr(config, property) for property in properties if hasattr(config, property)}
+        if hasattr(config, "tolerances"):
+            parameters["tolerances"] = config.tolerances.to_dict()
         return cls(problem=problem, **parameters)
 
     def __init__(self, problem=None, *args, **kwargs):

--- a/optlang/util.py
+++ b/optlang/util.py
@@ -288,6 +288,9 @@ class SolverTolerances(object):
             raise AttributeError(key + " is not an available tolerance parameter with this solver")
         self._functions[key][1](value)
 
+    def to_dict(self):
+        return {key: getattr(self, key) for key in self._functions.keys()}
+
     def __dir__(self):
         return list(self._functions)
 


### PR DESCRIPTION
This fixes #188:

```Python
In [1]: from cobra.test import create_test_model                                                                                                                              

In [2]: solver = create_test_model("textbook").solver                                                                                                                         

In [4]: solver.configuration.tolerances.feasibility = 1e-5                                                                                                                    

In [5]: import pickle                                                                                                                                                         

In [6]: pickled = pickle.dumps(solver)                                                                                                                                        

In [7]: solver = pickle.loads(pickled)                                                                                                                                        

In [8]: solver.configuration.tolerances.feasibility                                                                                                                           
Out[8]: 1e-05
```

There was actually no problem with pickling itself but rather with the fact that cloning a `Configuration` objects does not conserve the tolerances. I added to GLPK but could not make it work for CPLEX which seems to have some other issues. In CPLEX instantiating the configuration object you get one without the "tolerances" attribute and I could not figure out why.  
