### PR TITLE
Test for cloning and pickling configuration object in GLPK interface

### DIFF
--- a/optlang/tests/test_glpk_interface.py
+++ b/optlang/tests/test_glpk_interface.py
@@ -112,6 +112,21 @@ class ObjectiveTestCase(abstract_test_cases.AbstractObjectiveTestCase):
 
 class ConfigurationTestCase(abstract_test_cases.AbstractConfigurationTestCase):
     interface = glpk_interface
+    
+    def test_pickle_ability(self):
+        config = self.interface.Configuration()
+        config.tolerances.feasibility = 1e-01
+        value = config.tolerances.feasibility
+        pickle_string = pickle.dumps(config)
+        from_pickle = pickle.loads(pickle_string)
+        self.assertEqual(value, from_pickle.tolerances.feasibility)
+
+    def test_clone(self):
+        config = self.interface.Configuration()
+        config.tolerances.feasibility = 1e-01
+        value = config.tolerances.feasibility
+        cloned_config = config.clone(config, problem=config.problem)
+        self.assertEqual(value, cloned_config.tolerances.feasibility)
 
 
 class ModelTestCase(abstract_test_cases.AbstractModelTestCase):


### PR DESCRIPTION
Hi all,

I wrote a couple of tests to check if the feasibility tolerance is preserved when pickling and cloning a configuration object in the glpk interface. This PR would require prior merge of #189.

Best,
Justin