### PR TITLE
fix: pin colorama version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,15 @@ sudo: false
 git:
   depth: 2
 python:
-  - '2.7'
-  - '3.4'
-  - '3.5'
-  - '3.6'
+  - "2.7"
+  - "3.4"
+  - "3.5"
+  - "3.6"
 branches:
   only:
-  - master
-  - devel
-  - "/^\\d+\\.\\d+\\.\\d+[a]?\\d*$/"
+    - master
+    - devel
+    - "/^\\d+\\.\\d+\\.\\d+[a]?\\d*$/"
 env:
   global:
     - GITHUB_REPO=biosustain/optlang
@@ -29,7 +29,7 @@ before_install:
   - 'echo "this is a build for: $TRAVIS_BRANCH"'
   - 'if [[ "$TRAVIS_PYTHON_VERSION" < "3.5" ]]; then bash ./.travis/install_cplex.sh; fi'
 install:
-  - pip install nose nose-progressive rednose coverage docutils flake8 codecov jsonschema
+  - pip install nose nose-progressive colorama==0.4.0 rednose coverage docutils flake8 codecov jsonschema
   - pip install -r requirements.txt
   - pip install scipy
   - 'if [[ "$OPTLANG_USE_SYMENGINE" = "True" ]]; then pip install symengine; fi'
@@ -50,7 +50,7 @@ deploy:
     on:
       tags: true
       repo: $GITHUB_REPO
-      python: '3.6'
+      python: "3.6"
       condition: $OPTLANG_USE_SYMENGINE = False
   - provider: pypi
     skip_cleanup: true
@@ -61,5 +61,5 @@ deploy:
     on:
       tags: true
       repo: $GITHUB_REPO
-      python: '3.6'
+      python: "3.6"
       condition: $OPTLANG_USE_SYMENGINE = False

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
   - 'echo "this is a build for: $TRAVIS_BRANCH"'
   - 'if [[ "$TRAVIS_PYTHON_VERSION" < "3.5" ]]; then bash ./.travis/install_cplex.sh; fi'
 install:
-  - pip install nose nose-progressive colorama==0.4.0 rednose coverage docutils flake8 codecov jsonschema
+  - pip install nose nose-progressive colorama==0.3.9 rednose coverage docutils flake8 codecov jsonschema
   - pip install -r requirements.txt
   - pip install scipy
   - 'if [[ "$OPTLANG_USE_SYMENGINE" = "True" ]]; then pip install symengine; fi'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 branches:
- only:
- - master
- - devel
- - "/^\\d+\\.\\d+\\.\\d+[a]?\\d*$/"
+  only:
+    - master
+    - devel
+    - "/^\\d+\\.\\d+\\.\\d+[a]?\\d*$/"
 
 environment:
   global:
@@ -31,14 +31,12 @@ init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%bit"
 
 cache:
-    - pip_cache -> appveyor.yml
-
+  - pip_cache -> appveyor.yml
 
 install:
   - "powershell appveyor\\install.ps1"
   - "%PYTHON%/python -m pip install pip setuptools wheel --upgrade"
-  - "%PYTHON%/python -m pip install nose rednose swiglpk coverage jsonschema numpy"
-
+  - "%PYTHON%/python -m pip install nose colorama==0.3.9 rednose swiglpk coverage jsonschema numpy"
 
 build: off
 

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,13 @@ else:
 
 
 extra_requirements = {
-    'test': ['nose>=1.3.7', 'rednose>=0.4.3', 'coverage>=4.0.3', 'jsonschema>=2.5'],
+    'test': [
+        'nose>=1.3.7',
+        'colorama==0.4.0',
+        'rednose>=0.4.3',
+        'coverage>=4.0.3',
+        'jsonschema>=2.5'
+    ],
 }
 extra_requirements['all'] = list(set(chain(*extra_requirements.values())))
 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ else:
 extra_requirements = {
     'test': [
         'nose>=1.3.7',
-        'colorama==0.4.0',
+        'colorama==0.3.9',
         'rednose>=0.4.3',
         'coverage>=4.0.3',
         'jsonschema>=2.5'

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ commands=flake8 .
 
 [testenv]
 deps=nose
-     colorama ~= 0.4.0
+     colorama ~= 0.3.9
      rednose
      swiglpk
      coverage

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@ commands=flake8 .
 
 [testenv]
 deps=nose
+     colorama ~= 0.4.0
      rednose
      swiglpk
      coverage


### PR DESCRIPTION
Fix build for 13673ac26f6b3ba37a2ef392489722c52e3c5ff1.
The build is failing because colorama no longer supports python 3.4. The latest version to support it is [colorama 0.3.9](https://github.com/tartley/colorama/blob/master/CHANGELOG.rst).